### PR TITLE
Yamahaアンプの電源ONとAirPlay入力切り替えへの対応

### DIFF
--- a/subcommand/action/yamaha/action_test.go
+++ b/subcommand/action/yamaha/action_test.go
@@ -9,7 +9,9 @@ import (
 type mockYamahaAPI struct {
 	setSceneFunc  func(ctx context.Context, scene int) error
 	setVolumeFunc func(ctx context.Context, volume int) error
+	powerOnFunc   func(ctx context.Context) error
 	powerOffFunc  func(ctx context.Context) error
+	setInputFunc  func(ctx context.Context, input string) error
 }
 
 func (m *mockYamahaAPI) SetScene(ctx context.Context, scene int) error {
@@ -18,8 +20,14 @@ func (m *mockYamahaAPI) SetScene(ctx context.Context, scene int) error {
 func (m *mockYamahaAPI) SetVolume(ctx context.Context, volume int) error {
 	return m.setVolumeFunc(ctx, volume)
 }
+func (m *mockYamahaAPI) PowerOn(ctx context.Context) error {
+	return m.powerOnFunc(ctx)
+}
 func (m *mockYamahaAPI) PowerOff(ctx context.Context) error {
 	return m.powerOffFunc(ctx)
+}
+func (m *mockYamahaAPI) SetInput(ctx context.Context, input string) error {
+	return m.setInputFunc(ctx, input)
 }
 
 func TestActions(t *testing.T) {
@@ -30,10 +38,27 @@ func TestActions(t *testing.T) {
 		setVolumeFunc: func(ctx context.Context, volume int) error {
 			return nil
 		},
+		powerOnFunc: func(ctx context.Context) error {
+			return nil
+		},
 		powerOffFunc: func(ctx context.Context) error {
 			return nil
 		},
+		setInputFunc: func(ctx context.Context, input string) error {
+			return nil
+		},
 	}
+
+	t.Run("PowerOnAction", func(t *testing.T) {
+		action := NewPowerOnAction(mock)
+		got, err := action.Run(context.Background(), "")
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !strings.Contains(got, "Power on") {
+			t.Errorf("Unexpected result: %s", got)
+		}
+	})
 
 	t.Run("PowerOffAction", func(t *testing.T) {
 		action := NewPowerOffAction(mock)
@@ -64,6 +89,17 @@ func TestActions(t *testing.T) {
 			t.Fatalf("Run() error = %v", err)
 		}
 		if !strings.Contains(got, "volume to 70") {
+			t.Errorf("Unexpected result: %s", got)
+		}
+	})
+
+	t.Run("SetInputAction", func(t *testing.T) {
+		action := NewSetInputAction(mock, "airplay")
+		got, err := action.Run(context.Background(), "")
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !strings.Contains(got, "input to airplay") {
 			t.Errorf("Unexpected result: %s", got)
 		}
 	})

--- a/subcommand/action/yamaha/client.go
+++ b/subcommand/action/yamaha/client.go
@@ -18,7 +18,9 @@ const basePath = "YamahaExtendedControl/v1/main/"
 type YamahaAPI interface {
 	SetScene(ctx context.Context, scene int) error
 	SetVolume(ctx context.Context, volume int) error
+	PowerOn(ctx context.Context) error
 	PowerOff(ctx context.Context) error
+	SetInput(ctx context.Context, input string) error
 }
 
 type Client struct {
@@ -106,6 +108,24 @@ func (c Client) SetVolume(ctx context.Context, volume int) error {
 	return nil
 }
 
+func (c Client) PowerOn(ctx context.Context) error {
+	params := map[string]string{}
+	params["power"] = "on"
+	req, err := internal.BuildHttpRequestWithParams(ctx, http.MethodGet, c.buildUrl("setPower"), params)
+	if err != nil {
+		return err
+	}
+	res, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	err = parseHttpResponse(res, "PowerOn")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c Client) PowerOff(ctx context.Context) error {
 	params := map[string]string{}
 	params["power"] = "standby"
@@ -118,6 +138,24 @@ func (c Client) PowerOff(ctx context.Context) error {
 		return err
 	}
 	err = parseHttpResponse(res, "PowerOff")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Client) SetInput(ctx context.Context, input string) error {
+	params := map[string]string{}
+	params["input"] = input
+	req, err := internal.BuildHttpRequestWithParams(ctx, http.MethodGet, c.buildUrl("setInput"), params)
+	if err != nil {
+		return err
+	}
+	res, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	err = parseHttpResponse(res, "SetInput")
 	if err != nil {
 		return err
 	}

--- a/subcommand/action/yamaha/power-on.go
+++ b/subcommand/action/yamaha/power-on.go
@@ -1,0 +1,29 @@
+package yamaha
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+)
+
+type PowerOnAction struct {
+	name string
+	c    YamahaAPI
+}
+
+func (a PowerOnAction) Run(ctx context.Context, _ string) (string, error) {
+	ctx, span := otel.Tracer("yamaha").Start(ctx, "PowerOnAction.Run")
+	defer span.End()
+	err := a.c.PowerOn(ctx)
+	if err != nil {
+		return "", err
+	}
+	return "Power on Yamaha.", nil
+}
+
+func NewPowerOnAction(client YamahaAPI) PowerOnAction {
+	return PowerOnAction{
+		name: "Power On Yamaha",
+		c:    client,
+	}
+}

--- a/subcommand/action/yamaha/set-input.go
+++ b/subcommand/action/yamaha/set-input.go
@@ -1,0 +1,31 @@
+package yamaha
+
+import (
+	"context"
+	"fmt"
+	"go.opentelemetry.io/otel"
+)
+
+type SetInputAction struct {
+	name  string
+	input string
+	c     YamahaAPI
+}
+
+func (a SetInputAction) Run(ctx context.Context, _ string) (string, error) {
+	ctx, span := otel.Tracer("yamaha").Start(ctx, "SetInputAction.Run")
+	defer span.End()
+	err := a.c.SetInput(ctx, a.input)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Set input to %v.", a.input), nil
+}
+
+func NewSetInputAction(client YamahaAPI, input string) SetInputAction {
+	return SetInputAction{
+		name:  "Set Yamaha Input",
+		input: input,
+		c:     client,
+	}
+}

--- a/subcommand/change-playlist.go
+++ b/subcommand/change-playlist.go
@@ -3,6 +3,7 @@ package subcommand
 import (
 	"github.com/johtani/smarthome/subcommand/action"
 	"github.com/johtani/smarthome/subcommand/action/owntone"
+	"github.com/johtani/smarthome/subcommand/action/yamaha"
 )
 
 const ChangePlaylistCmd = "change playlist"
@@ -17,10 +18,13 @@ func NewChangePlaylistCmdDefinition() Definition {
 
 func NewChangePlaylistSubcommand(definition Definition, config Config) Subcommand {
 	owntoneClient := owntone.NewClient(config.Owntone)
+	yamahaClient := yamaha.NewClient(config.Yamaha)
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{
 			owntone.NewClearQueueAction(owntoneClient),
+			yamaha.NewPowerOnAction(yamahaClient),
+			yamaha.NewSetInputAction(yamahaClient, "airplay"),
 			owntone.NewChangePlaylistAction(owntoneClient),
 		},
 		ignoreError: true,

--- a/subcommand/finish-meeting.go
+++ b/subcommand/finish-meeting.go
@@ -24,6 +24,8 @@ func NewFinishMeetingSubcommand(definition Definition, config Config) Subcommand
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{
+			yamaha.NewPowerOnAction(yamahaClient),
+			yamaha.NewSetInputAction(yamahaClient, "airplay"),
 			owntone.NewPlayAction(owntoneClient),
 			action.NewNoOpAction(3 * time.Second),
 			yamaha.NewSetVolumeAction(yamahaClient, 39),

--- a/subcommand/search-and-play.go
+++ b/subcommand/search-and-play.go
@@ -30,6 +30,8 @@ func NewSearchAndPlayMusicSubcommand(definition Definition, config Config) Subco
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{
+			yamaha.NewPowerOnAction(yamahaClient),
+			yamaha.NewSetInputAction(yamahaClient, "airplay"),
 			owntone.NewSearchAndPlayAction(owntoneClient),
 			action.NewNoOpAction(3 * time.Second),
 			yamaha.NewSetVolumeAction(yamahaClient, 39),

--- a/subcommand/start-music.go
+++ b/subcommand/start-music.go
@@ -25,6 +25,8 @@ func NewStartMusicSubcommand(definition Definition, config Config) Subcommand {
 		Definition: definition,
 		actions: []action.Action{
 			owntone.NewClearQueueAction(owntoneClient),
+			yamaha.NewPowerOnAction(yamahaClient),
+			yamaha.NewSetInputAction(yamahaClient, "airplay"),
 			owntone.NewPlayAction(owntoneClient),
 			action.NewNoOpAction(3 * time.Second),
 			yamaha.NewSetVolumeAction(yamahaClient, 39),


### PR DESCRIPTION
ヤマハのアンプが電源オフ（ネットワークスタンバイ）の状態から復帰する際、音量設定だけでは電源が入らない、あるいは入力が切り替わらない問題に対応しました。

### 変更内容
- Yamaha APIクライアントに PowerOn と SetInput メソッドを追加
- PowerOnAction と SetInputAction を新規作成
- start-music, search-and-play, finish-meeting, change-playlist の各サブコマンドに上記Actionを追加し、再生前に明示的に電源ONと入力切り替えを行うように変更
- 関連するテストの更新および追加