### PR TITLE
Implement fuzzy matching for subcommand arguments (#55)

### DIFF
--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -25,6 +25,7 @@ func TestParse(t *testing.T) {
 		{name: "Term and offset, limit", args: args{target: "term offset:1 limit:2"}, want: &SearchQuery{Terms: []string{"term"}, Offset: 1, Limit: 2}},
 		{name: "Term and offset, limit, types", args: args{target: "term offset:1 limit:2 type:album type:artist"}, want: &SearchQuery{Terms: []string{"term"}, Offset: 1, Limit: 2, Types: []SearchType{album, artist}}},
 		{name: "Term genre type", args: args{target: "term type:genre"}, want: &SearchQuery{Terms: []string{"term"}, Offset: -1, Limit: -1, Types: []SearchType{genre}}},
+		{name: "Term genre type misspelled", args: args{target: "term type:gener"}, want: &SearchQuery{Terms: []string{"term"}, Offset: -1, Limit: -1, Types: []SearchType{genre}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/subcommand/subcommand_test.go
+++ b/subcommand/subcommand_test.go
@@ -310,3 +310,61 @@ func TestCommands_Find(t *testing.T) {
 		})
 	}
 }
+
+func TestArg_Match(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     Arg
+		input   string
+		wantVal string
+		wantOk  bool
+	}{
+		{
+			name:    "Enum match",
+			arg:     Arg{Name: "type", Enum: []string{"artist", "album"}},
+			input:   "artist",
+			wantVal: "artist",
+			wantOk:  true,
+		},
+		{
+			name:    "Enum fuzzy match",
+			arg:     Arg{Name: "type", Enum: []string{"artist", "album"}},
+			input:   "artst",
+			wantVal: "artist",
+			wantOk:  true,
+		},
+		{
+			name:    "Prefix and Enum match",
+			arg:     Arg{Name: "type", Prefix: "type:", Enum: []string{"artist", "album"}},
+			input:   "type:album",
+			wantVal: "album",
+			wantOk:  true,
+		},
+		{
+			name:    "Prefix and Enum fuzzy match",
+			arg:     Arg{Name: "type", Prefix: "type:", Enum: []string{"artist", "album"}},
+			input:   "type:alum",
+			wantVal: "album",
+			wantOk:  true,
+		},
+		{
+			name:    "No match",
+			arg:     Arg{Name: "type", Enum: []string{"artist", "album"}},
+			input:   "something",
+			wantVal: "",
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotOk := tt.arg.Match(tt.input)
+			if gotOk != tt.wantOk {
+				t.Errorf("Match() ok = %v, want %v", gotOk, tt.wantOk)
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("Match() val = %v, want %v", gotVal, tt.wantVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue #55 の「引数の『もしかして』対応」を実装しました。

### 変更内容

1. subcommand/subcommand.go
   - Arg 構造体に Match メソッドを追加。Enum に対して曖昧一致を導入。
2. subcommand/action/owntone/client.go
   - SearchTypeFromString 関数に曖昧一致ロジックを実装。
3. テストの追加
   - 関連するテストケースを追加。