### PR TITLE
Issue 106: Add health check functionality

### DIFF
--- a/subcommand/action/healthcheck/healthcheck.go
+++ b/subcommand/action/healthcheck/healthcheck.go
@@ -1,0 +1,76 @@
+/*
+Package healthcheck provides actions for checking the health of various services.
+*/
+package healthcheck
+
+import (
+	"context"
+
+	"github.com/johtani/smarthome/subcommand/action/owntone"
+	"github.com/johtani/smarthome/subcommand/action/switchbot"
+	"github.com/johtani/smarthome/subcommand/action/yamaha"
+	"go.opentelemetry.io/otel"
+)
+
+// SwitchBotHealthCheckAction checks the health of the SwitchBot API.
+type SwitchBotHealthCheckAction struct {
+	client *switchbot.CachedClient
+}
+
+// Run executes the SwitchBotHealthCheckAction.
+func (a SwitchBotHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
+	ctx, span := otel.Tracer("healthcheck").Start(ctx, "SwitchBotHealthCheckAction.Run")
+	defer span.End()
+	_, _, err := a.client.DeviceAPI.List(ctx)
+	if err != nil {
+		return "SwitchBot: Error (" + err.Error() + ")", nil
+	}
+	return "SwitchBot: OK", nil
+}
+
+// NewSwitchBotHealthCheckAction creates a new SwitchBotHealthCheckAction.
+func NewSwitchBotHealthCheckAction(client *switchbot.CachedClient) SwitchBotHealthCheckAction {
+	return SwitchBotHealthCheckAction{client: client}
+}
+
+// OwnToneHealthCheckAction checks the health of the OwnTone API.
+type OwnToneHealthCheckAction struct {
+	client *owntone.Client
+}
+
+// Run executes the OwnToneHealthCheckAction.
+func (a OwnToneHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
+	ctx, span := otel.Tracer("healthcheck").Start(ctx, "OwnToneHealthCheckAction.Run")
+	defer span.End()
+	_, err := a.client.Counts(ctx)
+	if err != nil {
+		return "OwnTone: Error (" + err.Error() + ")", nil
+	}
+	return "OwnTone: OK", nil
+}
+
+// NewOwnToneHealthCheckAction creates a new OwnToneHealthCheckAction.
+func NewOwnToneHealthCheckAction(client *owntone.Client) OwnToneHealthCheckAction {
+	return OwnToneHealthCheckAction{client: client}
+}
+
+// YamahaHealthCheckAction checks the health of the Yamaha API.
+type YamahaHealthCheckAction struct {
+	client yamaha.API
+}
+
+// Run executes the YamahaHealthCheckAction.
+func (a YamahaHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
+	ctx, span := otel.Tracer("healthcheck").Start(ctx, "YamahaHealthCheckAction.Run")
+	defer span.End()
+	err := a.client.GetDeviceInfo(ctx)
+	if err != nil {
+		return "Yamaha: Error (" + err.Error() + ")", nil
+	}
+	return "Yamaha: OK", nil
+}
+
+// NewYamahaHealthCheckAction creates a new YamahaHealthCheckAction.
+func NewYamahaHealthCheckAction(client yamaha.API) YamahaHealthCheckAction {
+	return YamahaHealthCheckAction{client: client}
+}

--- a/subcommand/action/healthcheck/healthcheck_test.go
+++ b/subcommand/action/healthcheck/healthcheck_test.go
@@ -1,0 +1,55 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type mockYamahaAPI struct {
+	getDeviceInfoFunc func(ctx context.Context) error
+}
+
+func (m *mockYamahaAPI) SetScene(ctx context.Context, scene int) error    { return nil }
+func (m *mockYamahaAPI) SetVolume(ctx context.Context, volume int) error  { return nil }
+func (m *mockYamahaAPI) PowerOn(ctx context.Context) error                { return nil }
+func (m *mockYamahaAPI) PowerOff(ctx context.Context) error               { return nil }
+func (m *mockYamahaAPI) SetInput(ctx context.Context, input string) error { return nil }
+func (m *mockYamahaAPI) GetDeviceInfo(ctx context.Context) error {
+	return m.getDeviceInfoFunc(ctx)
+}
+
+func TestYamahaHealthCheckAction(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mock := &mockYamahaAPI{
+			getDeviceInfoFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+		action := NewYamahaHealthCheckAction(mock)
+		got, err := action.Run(context.Background(), "")
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got != "Yamaha: OK" {
+			t.Errorf("got %q, want %q", got, "Yamaha: OK")
+		}
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		mock := &mockYamahaAPI{
+			getDeviceInfoFunc: func(ctx context.Context) error {
+				return errors.New("connection error")
+			},
+		}
+		action := NewYamahaHealthCheckAction(mock)
+		got, err := action.Run(context.Background(), "")
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !strings.Contains(got, "Yamaha: Error") {
+			t.Errorf("expected error message, got %q", got)
+		}
+	})
+}

--- a/subcommand/action/yamaha/action_test.go
+++ b/subcommand/action/yamaha/action_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 type mockYamahaAPI struct {
-	setSceneFunc  func(ctx context.Context, scene int) error
-	setVolumeFunc func(ctx context.Context, volume int) error
-	powerOnFunc   func(ctx context.Context) error
-	powerOffFunc  func(ctx context.Context) error
-	setInputFunc  func(ctx context.Context, input string) error
+	setSceneFunc      func(ctx context.Context, scene int) error
+	setVolumeFunc     func(ctx context.Context, volume int) error
+	powerOnFunc       func(ctx context.Context) error
+	powerOffFunc      func(ctx context.Context) error
+	setInputFunc      func(ctx context.Context, input string) error
+	getDeviceInfoFunc func(ctx context.Context) error
 }
 
 func (m *mockYamahaAPI) SetScene(ctx context.Context, scene int) error {
@@ -28,6 +29,9 @@ func (m *mockYamahaAPI) PowerOff(ctx context.Context) error {
 }
 func (m *mockYamahaAPI) SetInput(ctx context.Context, input string) error {
 	return m.setInputFunc(ctx, input)
+}
+func (m *mockYamahaAPI) GetDeviceInfo(ctx context.Context) error {
+	return m.getDeviceInfoFunc(ctx)
 }
 
 func TestActions(t *testing.T) {

--- a/subcommand/action/yamaha/client.go
+++ b/subcommand/action/yamaha/client.go
@@ -23,6 +23,7 @@ type API interface {
 	PowerOn(ctx context.Context) error
 	PowerOff(ctx context.Context) error
 	SetInput(ctx context.Context, input string) error
+	GetDeviceInfo(ctx context.Context) error
 }
 
 // Client is a client for the Yamaha MusicCast API.
@@ -51,6 +52,14 @@ func (c Client) buildURL(path string) string {
 		url += "/"
 	}
 	return url + basePath + path
+}
+
+func (c Client) buildSystemURL(path string) string {
+	url := c.config.URL
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	return url + "YamahaExtendedControl/v1/system/" + path
 }
 
 // NewClient creates a new Yamaha client with the given configuration.
@@ -178,6 +187,24 @@ func (c Client) SetInput(ctx context.Context, input string) error {
 		return err
 	}
 	err = parseHTTPResponse(res, "SetInput")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetDeviceInfo gets the device information from the Yamaha device.
+func (c Client) GetDeviceInfo(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildSystemURL("getDeviceInfo"), nil)
+	if err != nil {
+		return err
+	}
+	// #nosec G704
+	res, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	err = parseHTTPResponse(res, "GetDeviceInfo")
 	if err != nil {
 		return err
 	}

--- a/subcommand/health.go
+++ b/subcommand/health.go
@@ -1,0 +1,37 @@
+package subcommand
+
+import (
+	"github.com/johtani/smarthome/subcommand/action"
+	"github.com/johtani/smarthome/subcommand/action/healthcheck"
+	"github.com/johtani/smarthome/subcommand/action/owntone"
+	"github.com/johtani/smarthome/subcommand/action/switchbot"
+	"github.com/johtani/smarthome/subcommand/action/yamaha"
+)
+
+// HealthCmd is the command name for checking the health of the system.
+const HealthCmd = "health"
+
+// NewHealthDefinition creates the definition for the health check command.
+func NewHealthDefinition() Definition {
+	return Definition{
+		Name:        HealthCmd,
+		Description: "Check the health of the smart home system",
+		Factory:     NewHealthSubcommand,
+	}
+}
+
+// NewHealthSubcommand creates a new Subcommand for the health check command.
+func NewHealthSubcommand(definition Definition, config Config) Subcommand {
+	switchbotClient := switchbot.NewClient(config.Switchbot)
+	owntoneClient := owntone.NewClient(config.Owntone)
+	yamahaClient := yamaha.NewClient(config.Yamaha)
+
+	return Subcommand{
+		Definition: definition,
+		actions: []action.Action{
+			healthcheck.NewSwitchBotHealthCheckAction(switchbotClient),
+			healthcheck.NewOwnToneHealthCheckAction(owntoneClient),
+			healthcheck.NewYamahaHealthCheckAction(yamahaClient),
+		},
+	}
+}

--- a/subcommand/subcommand.go
+++ b/subcommand/subcommand.go
@@ -194,6 +194,7 @@ func NewCommands() Commands {
 			NewLightOffDefinition(),
 			NewLightOnDefinition(),
 			NewHelpDefinition(),
+			NewHealthDefinition(),
 			NewStartSwitchDefinition(),
 			NewStartPS5Definition(),
 			NewAirConditionerOnDefinition(),


### PR DESCRIPTION
Issue 106: Implementation of Health Check Function

### Implementation Details
- **Yamaha API Client**: Added GetDeviceInfo method for connectivity checks.
- **Action Package**: Created a new subcommand/action/healthcheck package and implemented health check actions for SwitchBot, OwnTone, and Yamaha.
- **Subcommand**: Added the health subcommand to check the status of each service and report the results.
- **OpenTelemetry**: Integrated Span creation into each health check action.

### Verification
- Confirmed that all tests pass with go test ./....
- Confirmed no static analysis errors with golangci-lint run ./....

### Usage
Run the health command from Slack or the CLI to check the status:
`	ext
$ smarthome health
SwitchBot: OK
OwnTone: OK
Yamaha: OK
`