### PR TITLE
Detect and skip macros with conflicting names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ smarthome device list
 ]
 ```
 
+#### 注意：マクロ名の重複
+
+マクロの `name` に既存の組み込みコマンド名、または他のマクロと同じ名前を指定した場合、そのマクロは**スキップ**されます（起動時にwarningログが出力されます）。
+
+```
+WARN macro skipped: name already registered macro_name=help
+```
+
+組み込みコマンドの一覧は `help` コマンドで確認できます。
+
 #### アクションタイプ一覧
 
 | タイプ | 説明 | パラメータ |

--- a/subcommand/subcommand.go
+++ b/subcommand/subcommand.go
@@ -196,8 +196,18 @@ func NewCommands(macros ...MacroConfig) Commands {
 		NewTokenizeUniDefinition(),
 		NewTokenizeNeologdDefinition(),
 	}
+	existingNames := make(map[string]struct{})
+	for _, d := range defs {
+		existingNames[d.Name] = struct{}{}
+	}
+
 	for _, macro := range macros {
+		if _, exists := existingNames[macro.Name]; exists {
+			slog.Warn("macro skipped: name already registered", "macro_name", macro.Name)
+			continue
+		}
 		defs = append(defs, newMacroDefinition(macro))
+		existingNames[macro.Name] = struct{}{}
 	}
 	return Commands{Definitions: defs}
 }

--- a/subcommand/subcommand_test.go
+++ b/subcommand/subcommand_test.go
@@ -26,6 +26,36 @@ func NewDummySubcommand(definition Definition, _ Config) Subcommand {
 	}
 }
 
+func TestNewCommands(t *testing.T) {
+	base := NewCommands()
+	baseCount := len(base.Definitions)
+
+	t.Run("no conflict macro is registered", func(t *testing.T) {
+		cmds := NewCommands(MacroConfig{Name: "unique-macro", Description: "test"})
+		if got := len(cmds.Definitions); got != baseCount+1 {
+			t.Errorf("expected %d definitions, got %d", baseCount+1, got)
+		}
+	})
+
+	t.Run("macro conflicting with static command is skipped", func(t *testing.T) {
+		// "help" is a static command registered by NewHelpDefinition
+		cmds := NewCommands(MacroConfig{Name: "help", Description: "test"})
+		if got := len(cmds.Definitions); got != baseCount {
+			t.Errorf("expected %d definitions (no change), got %d", baseCount, got)
+		}
+	})
+
+	t.Run("second macro with duplicate name is skipped", func(t *testing.T) {
+		cmds := NewCommands(
+			MacroConfig{Name: "my-macro", Description: "first"},
+			MacroConfig{Name: "my-macro", Description: "second"},
+		)
+		if got := len(cmds.Definitions); got != baseCount+1 {
+			t.Errorf("expected %d definitions, got %d", baseCount+1, got)
+		}
+	})
+}
+
 func TestSubcommand_Exec(t *testing.T) {
 	type fields struct {
 		Name        string


### PR DESCRIPTION
## Summary
- `NewCommands()` でマクロ登録時に名前の重複を検出するようにした
- 組み込みコマンドまたは先に登録されたマクロと同名の場合、そのマクロをスキップして `slog.Warn` を出力する
- `TestNewCommands` を追加（重複なし・静的コマンドとの衝突・マクロ同士の衝突の3ケース）
- README にマクロ名重複時の挙動を注意書きとして追記

## Test plan
- [ ] `go test ./subcommand/...` が通ること
- [ ] `macros.json` に既存コマンド名（例: `help`）と同名のマクロを定義して起動し、warningログが出力されることを確認

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)