### PR TITLE
Validate macros with empty actions

### DIFF
--- a/subcommand/config_test.go
+++ b/subcommand/config_test.go
@@ -357,4 +357,25 @@ func TestLoadMacrosFromFile(t *testing.T) {
 			t.Errorf("expected unknown action type error, got: %v", err)
 		}
 	})
+
+	t.Run("empty actions", func(t *testing.T) {
+		content := `[{"name": "bad", "actions": []}]`
+		f, err := os.CreateTemp("", "macros_test_*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Remove(f.Name()) }()
+		if _, err := f.WriteString(content); err != nil {
+			t.Fatal(err)
+		}
+		_ = f.Close()
+
+		_, err = loadMacrosFromFile(f.Name())
+		if err == nil {
+			t.Fatal("expected validation error for empty actions")
+		}
+		if !strings.Contains(err.Error(), "actions must not be empty") {
+			t.Errorf("expected empty actions error, got: %v", err)
+		}
+	})
 }

--- a/subcommand/macro.go
+++ b/subcommand/macro.go
@@ -48,6 +48,9 @@ var knownActionTypes = map[string]struct{}{
 func validateMacros(macros []MacroConfig) error {
 	var errs []string
 	for _, macro := range macros {
+		if len(macro.Actions) == 0 {
+			errs = append(errs, fmt.Sprintf("macro %q: actions must not be empty", macro.Name))
+		}
 		for _, spec := range macro.Actions {
 			if _, ok := knownActionTypes[spec.Type]; !ok {
 				errs = append(errs, fmt.Sprintf("macro %q: unknown action type %q", macro.Name, spec.Type))

--- a/subcommand/macro_test.go
+++ b/subcommand/macro_test.go
@@ -60,6 +60,25 @@ func TestValidateMacros(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "empty actions",
+			macros: []MacroConfig{
+				{
+					Name:    "empty actions macro",
+					Actions: []ActionSpec{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil actions",
+			macros: []MacroConfig{
+				{
+					Name: "nil actions macro",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add validation error when a macro has no actions (len(actions) == 0)
- keep existing unknown action type validation behavior
- add tests for empty/nil actions in TestValidateMacros
- add loadMacrosFromFile test for empty actions validation

## Related
- Closes #127