### PR TITLE
llm.Resolveのリクエスト/レスポンスをトレース出力する

### DIFF
--- a/subcommand/action/llm/client.go
+++ b/subcommand/action/llm/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -62,6 +63,15 @@ type ResolvedCommand struct {
 	Thought string `json:"thought"`
 }
 
+const maxTraceBodyLength = 4096
+
+func truncateForTrace(v string) string {
+	if len(v) <= maxTraceBodyLength {
+		return v
+	}
+	return v[:maxTraceBodyLength] + "...truncated"
+}
+
 // Resolve resolves the given text to a command using the LLM.
 func (c *Client) Resolve(ctx context.Context, text string, commandList string) (ResolvedCommand, error) {
 	ctx, span := otel.Tracer("llm").Start(ctx, "llm.Resolve", trace.WithAttributes(
@@ -100,6 +110,10 @@ func (c *Client) Resolve(ctx context.Context, text string, commandList string) (
 	if err != nil {
 		return ResolvedCommand{}, fmt.Errorf("failed to marshal payload: %w", err)
 	}
+	span.SetAttributes(
+		attribute.String("llm.endpoint", c.config.Endpoint),
+		attribute.String("llm.request_body", truncateForTrace(string(jsonData))),
+	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.Endpoint, strings.NewReader(string(jsonData)))
 	if err != nil {
@@ -119,8 +133,26 @@ func (c *Client) Resolve(ctx context.Context, text string, commandList string) (
 		_ = resp.Body.Close()
 	}()
 
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ResolvedCommand{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+	span.SetAttributes(
+		attribute.Int("llm.response_status_code", resp.StatusCode),
+		attribute.String("llm.response_body", truncateForTrace(string(responseBody))),
+	)
+
 	if resp.StatusCode != http.StatusOK {
-		slog.ErrorContext(ctx, "LLM API returned error status", "status", resp.StatusCode, "endpoint", c.config.Endpoint)
+		slog.ErrorContext(
+			ctx,
+			"LLM API returned error status",
+			"status",
+			resp.StatusCode,
+			"endpoint",
+			c.config.Endpoint,
+			"response_body",
+			truncateForTrace(string(responseBody)),
+		)
 		return ResolvedCommand{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
@@ -132,7 +164,7 @@ func (c *Client) Resolve(ctx context.Context, text string, commandList string) (
 		} `json:"choices"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(responseBody, &result); err != nil {
 		return ResolvedCommand{}, fmt.Errorf("failed to decode response: %w", err)
 	}
 

--- a/subcommand/action/llm/client_test.go
+++ b/subcommand/action/llm/client_test.go
@@ -4,10 +4,19 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestClient_Resolve(t *testing.T) {
+	exporter, shutdown := setupTestTracerProvider(t)
+	defer shutdown()
+
 	mockResponse := struct {
 		Choices []struct {
 			Message struct {
@@ -60,6 +69,88 @@ func TestClient_Resolve(t *testing.T) {
 	if resolved.Thought == "" {
 		t.Error("expected thought to be non-empty")
 	}
+
+	span := findResolveSpan(t, exporter)
+	attrs := attrsAsMap(span.Attributes)
+
+	if attrs["llm.endpoint"] != server.URL {
+		t.Errorf("expected llm.endpoint %q, got %q", server.URL, attrs["llm.endpoint"])
+	}
+	if attrs["llm.request_body"] == "" {
+		t.Error("expected llm.request_body to be set")
+	}
+	if attrs["llm.response_body"] == "" {
+		t.Error("expected llm.response_body to be set")
+	}
+	if attrs["llm.response_status_code"] != "200" {
+		t.Errorf("expected llm.response_status_code 200, got %q", attrs["llm.response_status_code"])
+	}
+}
+
+func TestClient_ResolveErrorSetsResponseTraceAttributes(t *testing.T) {
+	exporter, shutdown := setupTestTracerProvider(t)
+	defer shutdown()
+
+	const errorBody = `{"error":"bad request"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, errorBody, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	config := Config{
+		Endpoint: server.URL,
+		Model:    "test-model",
+	}
+	client := NewClient(config)
+
+	_, err := client.Resolve(t.Context(), "電気をつけて", "light on: turn on the light")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	span := findResolveSpan(t, exporter)
+	attrs := attrsAsMap(span.Attributes)
+
+	if attrs["llm.response_status_code"] != "400" {
+		t.Errorf("expected llm.response_status_code 400, got %q", attrs["llm.response_status_code"])
+	}
+	if !strings.Contains(attrs["llm.response_body"], "bad request") {
+		t.Errorf("expected llm.response_body to contain error payload, got %q", attrs["llm.response_body"])
+	}
+}
+
+func TestClient_ResolveTruncatesLargeResponseBodyInTrace(t *testing.T) {
+	exporter, shutdown := setupTestTracerProvider(t)
+	defer shutdown()
+
+	longBody := strings.Repeat("x", maxTraceBodyLength+10)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(longBody))
+	}))
+	defer server.Close()
+
+	config := Config{
+		Endpoint: server.URL,
+		Model:    "test-model",
+	}
+	client := NewClient(config)
+
+	_, err := client.Resolve(t.Context(), "電気をつけて", "light on: turn on the light")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	span := findResolveSpan(t, exporter)
+	attrs := attrsAsMap(span.Attributes)
+	got := attrs["llm.response_body"]
+
+	if !strings.HasSuffix(got, "...truncated") {
+		t.Errorf("expected truncated suffix, got %q", got)
+	}
+	if len(got) != maxTraceBodyLength+len("...truncated") {
+		t.Errorf("expected truncated length %d, got %d", maxTraceBodyLength+len("...truncated"), len(got))
+	}
 }
 
 func TestConfig_Validate(t *testing.T) {
@@ -99,4 +190,41 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupTestTracerProvider(t *testing.T) (*tracetest.InMemoryExporter, func()) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSyncer(exporter),
+	)
+
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+
+	return exporter, func() {
+		_ = tp.Shutdown(t.Context())
+		otel.SetTracerProvider(prev)
+	}
+}
+
+func findResolveSpan(t *testing.T, exporter *tracetest.InMemoryExporter) tracetest.SpanStub {
+	t.Helper()
+	spans := exporter.GetSpans()
+	for _, s := range spans {
+		if s.Name == "llm.Resolve" {
+			return s
+		}
+	}
+	t.Fatalf("expected llm.Resolve span, got %d spans", len(spans))
+	return tracetest.SpanStub{}
+}
+
+func attrsAsMap(attrs []attribute.KeyValue) map[string]string {
+	m := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		m[string(kv.Key)] = kv.Value.Emit()
+	}
+	return m
 }


### PR DESCRIPTION
## 概要
Issue #132 に対応し、llm.Resolve から LLM API に送受信している内容をトレースで確認できるようにしました。

## 変更内容
- llm.request_body と llm.endpoint を span attribute に追加
- APIレスポンスを一度読み取り、llm.response_status_code と llm.response_body を span attribute に追加
- 非200レスポンス時のログに response body（truncate済み）を追加
- 既存の llm.response_content / llm.resolved_* 属性は維持
- 大きな payload/body を考慮して 	runcateForTrace を追加（4096文字）
- トレース属性を検証するテストを追加（正常系/エラー系/truncate）

## テスト
- go test ./subcommand/action/llm
- go test ./...

Closes #132