### PR TITLE
Fix #131: split music commands and stabilize LLM arg resolution

### DIFF
--- a/subcommand/action/fixed-args.go
+++ b/subcommand/action/fixed-args.go
@@ -1,0 +1,22 @@
+package action
+
+import "context"
+
+// FixedArgsAction wraps another action and always passes fixed args to it.
+type FixedArgsAction struct {
+	action Action
+	args   string
+}
+
+// Run executes the wrapped action with fixed args.
+func (a FixedArgsAction) Run(ctx context.Context, _ string) (string, error) {
+	return a.action.Run(ctx, a.args)
+}
+
+// NewFixedArgsAction creates a new FixedArgsAction.
+func NewFixedArgsAction(action Action, args string) FixedArgsAction {
+	return FixedArgsAction{
+		action: action,
+		args:   args,
+	}
+}

--- a/subcommand/action/llm/client.go
+++ b/subcommand/action/llm/client.go
@@ -87,6 +87,12 @@ func (c *Client) Resolve(ctx context.Context, text string, commandList string) (
 以下のコマンドリストから、ユーザーの意図に最も合致するものを選び、JSON形式で返してください。
 合致するものがない場合は、commandに空文字列を入れてください。
 
+選択ルール:
+- コマンドの args 指定に必ず従ってください（required/optional/enum/prefix）。
+- ユーザー入力に固有名詞（アーティスト名/曲名/アルバム名など）が含まれる再生要求は search and play を優先してください。
+- start music はランダム再生用途としてのみ使ってください。
+- 使うコマンドで解釈できない自由文字列を args に入れないでください。
+
 コマンドリスト:
 %s
 

--- a/subcommand/action/llm/client_test.go
+++ b/subcommand/action/llm/client_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,7 @@ import (
 func TestClient_Resolve(t *testing.T) {
 	exporter, shutdown := setupTestTracerProvider(t)
 	defer shutdown()
+	var requestBody string
 
 	mockResponse := struct {
 		Choices []struct {
@@ -46,6 +48,8 @@ func TestClient_Resolve(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("expected application/json content-type, got %s", r.Header.Get("Content-Type"))
 		}
+		body, _ := io.ReadAll(r.Body)
+		requestBody = string(body)
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(mockResponse)
@@ -68,6 +72,9 @@ func TestClient_Resolve(t *testing.T) {
 	}
 	if resolved.Thought == "" {
 		t.Error("expected thought to be non-empty")
+	}
+	if !strings.Contains(requestBody, "コマンドの args 指定に必ず従ってください") {
+		t.Errorf("expected prompt rule in request body, got %s", requestBody)
 	}
 
 	span := findResolveSpan(t, exporter)

--- a/subcommand/play-random-music.go
+++ b/subcommand/play-random-music.go
@@ -1,0 +1,78 @@
+package subcommand
+
+import (
+	"time"
+
+	"github.com/johtani/smarthome/subcommand/action"
+	"github.com/johtani/smarthome/subcommand/action/owntone"
+	"github.com/johtani/smarthome/subcommand/action/yamaha"
+)
+
+// PlayRandomPlaylistCmd is the command name for playing random playlist music.
+const PlayRandomPlaylistCmd = "play random playlist"
+
+// PlayRandomArtistCmd is the command name for playing random artist music.
+const PlayRandomArtistCmd = "play random artist"
+
+// PlayRandomGenreCmd is the command name for playing random genre music.
+const PlayRandomGenreCmd = "play random genre"
+
+// NewPlayRandomPlaylistCmdDefinition creates the definition for the random playlist command.
+func NewPlayRandomPlaylistCmdDefinition() Definition {
+	return Definition{
+		Name:        PlayRandomPlaylistCmd,
+		Description: "Play music from a random playlist",
+		Factory:     NewPlayRandomPlaylistSubcommand,
+	}
+}
+
+// NewPlayRandomArtistCmdDefinition creates the definition for the random artist command.
+func NewPlayRandomArtistCmdDefinition() Definition {
+	return Definition{
+		Name:        PlayRandomArtistCmd,
+		Description: "Play music from a random artist",
+		Factory:     NewPlayRandomArtistSubcommand,
+	}
+}
+
+// NewPlayRandomGenreCmdDefinition creates the definition for the random genre command.
+func NewPlayRandomGenreCmdDefinition() Definition {
+	return Definition{
+		Name:        PlayRandomGenreCmd,
+		Description: "Play music from a random genre",
+		Factory:     NewPlayRandomGenreSubcommand,
+	}
+}
+
+func newPlayRandomMusicSubcommand(definition Definition, config Config, mode string) Subcommand {
+	owntoneClient := owntone.NewClient(config.Owntone)
+	yamahaClient := yamaha.NewClient(config.Yamaha)
+	return Subcommand{
+		Definition: definition,
+		actions: []action.Action{
+			owntone.NewClearQueueAction(owntoneClient),
+			yamaha.NewPowerOnAction(yamahaClient),
+			yamaha.NewSetInputAction(yamahaClient, "airplay"),
+			action.NewFixedArgsAction(owntone.NewPlayAction(owntoneClient), mode),
+			action.NewNoOpAction(3 * time.Second),
+			yamaha.NewSetVolumeAction(yamahaClient, 39),
+			owntone.NewDisplayOutputsAction(owntoneClient, true),
+		},
+		ignoreError: true,
+	}
+}
+
+// NewPlayRandomPlaylistSubcommand creates a new Subcommand for random playlist playback.
+func NewPlayRandomPlaylistSubcommand(definition Definition, config Config) Subcommand {
+	return newPlayRandomMusicSubcommand(definition, config, "")
+}
+
+// NewPlayRandomArtistSubcommand creates a new Subcommand for random artist playback.
+func NewPlayRandomArtistSubcommand(definition Definition, config Config) Subcommand {
+	return newPlayRandomMusicSubcommand(definition, config, "artist")
+}
+
+// NewPlayRandomGenreSubcommand creates a new Subcommand for random genre playback.
+func NewPlayRandomGenreSubcommand(definition Definition, config Config) Subcommand {
+	return newPlayRandomMusicSubcommand(definition, config, "genre")
+}

--- a/subcommand/start-music.go
+++ b/subcommand/start-music.go
@@ -15,8 +15,11 @@ const StartMusicCmd = "start music"
 func NewStartMusicCmdDefinition() Definition {
 	return Definition{
 		Name:        StartMusicCmd,
-		Description: "Start Music from playlist or by artist or by genre",
+		Description: "Legacy command for random music playback (playlist/artist/genre)",
 		Factory:     NewStartMusicSubcommand,
+		Args: []Arg{
+			{"mode", "random target type", false, []string{"artist", "genre"}, ""},
+		},
 	}
 }
 

--- a/subcommand/subcommand.go
+++ b/subcommand/subcommand.go
@@ -115,6 +115,25 @@ func (d Definition) Help() string {
 	} else {
 		help = fmt.Sprintf("  %s : %s\n", d.Name, d.Description)
 	}
+	if len(d.Args) > 0 {
+		var items []string
+		for _, arg := range d.Args {
+			var details []string
+			if arg.Required {
+				details = append(details, "required")
+			} else {
+				details = append(details, "optional")
+			}
+			if arg.Prefix != "" {
+				details = append(details, "prefix="+arg.Prefix)
+			}
+			if len(arg.Enum) > 0 {
+				details = append(details, "enum="+strings.Join(arg.Enum, "|"))
+			}
+			items = append(items, fmt.Sprintf("%s(%s)", arg.Name, strings.Join(details, ",")))
+		}
+		help += fmt.Sprintf("    args: %s\n", strings.Join(items, ", "))
+	}
 	return help
 }
 
@@ -180,6 +199,9 @@ type Commands struct {
 func NewCommands(macros ...MacroConfig) Commands {
 	defs := []Definition{
 		NewStartMusicCmdDefinition(),
+		NewPlayRandomPlaylistCmdDefinition(),
+		NewPlayRandomArtistCmdDefinition(),
+		NewPlayRandomGenreCmdDefinition(),
 		NewStopMusicDefinition(),
 		NewChangePlaylistCmdDefinition(),
 		NewDisplayPalylistCmdDefinition(),
@@ -243,6 +265,14 @@ func (c Commands) Find(ctx context.Context, config Config, text string) (Definit
 			client := llm.NewClient(config.LLM)
 			resolved, err := client.Resolve(ctx, text, c.Help())
 			if err == nil && resolved.Command != "" {
+				// Backward-compatible safety fallback:
+				// if LLM resolves to start music with free-text args, use search and play.
+				if resolved.Command == StartMusicCmd &&
+					strings.TrimSpace(resolved.Args) != "" &&
+					!strings.HasPrefix(strings.TrimSpace(resolved.Args), "artist") &&
+					!strings.HasPrefix(strings.TrimSpace(resolved.Args), "genre") {
+					resolved.Command = SearchAndPlayMusicCmd
+				}
 				for _, d := range c.Definitions {
 					if d.Name == resolved.Command {
 						return d, resolved.Args, fmt.Sprintf("(LLM) %s", resolved.Thought), nil

--- a/subcommand/subcommand_llm_test.go
+++ b/subcommand/subcommand_llm_test.go
@@ -94,3 +94,39 @@ func TestCommands_Find_LLM(t *testing.T) {
 		}
 	})
 }
+
+func TestCommands_Find_LLM_FallbackStartMusicArgsToSearchAndPlay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"message":{"content":"{\"command\": \"start music\", \"args\": \"Meja\", \"thought\": \"music request\"}"}}]}`)
+	}))
+	defer server.Close()
+
+	config := Config{
+		LLM: llm.Config{
+			Endpoint: server.URL,
+			Model:    "test-model",
+		},
+	}
+
+	cmds := Commands{
+		Definitions: []Definition{
+			{Name: StartMusicCmd, Description: "legacy random music", Factory: NewDummySubcommand},
+			{Name: SearchAndPlayMusicCmd, Description: "search and play music", Factory: NewDummySubcommand},
+		},
+	}
+
+	def, args, msg, err := cmds.Find(t.Context(), config, "Mejaを再生して")
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if def.Name != SearchAndPlayMusicCmd {
+		t.Fatalf("expected command %q, got %q", SearchAndPlayMusicCmd, def.Name)
+	}
+	if args != "Meja" {
+		t.Fatalf("expected args %q, got %q", "Meja", args)
+	}
+	if msg != "(LLM) music request" {
+		t.Fatalf("unexpected msg: %s", msg)
+	}
+}

--- a/subcommand/subcommand_test.go
+++ b/subcommand/subcommand_test.go
@@ -155,6 +155,21 @@ func TestCommands_Help(t *testing.T) {
 				},
 			},
 			want: "  a : description\n  b [c]: description\n"},
+		{name: "command help with args",
+			fields: fields{
+				definitions: []Definition{
+					{
+						Name:        "search and play",
+						Description: "Search Music by keyword And play",
+						Factory:     NewDummySubcommand,
+						Args: []Arg{
+							{Name: "keyword", Required: true},
+							{Name: "type", Required: false, Enum: []string{"artist", "album"}, Prefix: "type:"},
+						},
+					},
+				},
+			},
+			want: "  search and play : Search Music by keyword And play\n    args: keyword(required), type(optional,prefix=type:,enum=artist|album)\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- split random music playback into dedicated commands: `play random playlist`, `play random artist`, `play random genre`
- keep `start music` as a legacy random-playback command and add explicit arg metadata
- improve LLM resolution by adding command-argument selection rules and command arg specs in help text
- add a safety fallback: if LLM returns `start music` with free-text args (e.g. artist name), route to `search and play`
- add tests for help arg rendering, LLM prompt rules, and fallback behavior

## Testing
- go test ./subcommand/...
- go test ./...

Closes #131