### PR TITLE
test: use filepath.Join in config tests

### DIFF
--- a/subcommand/config_test.go
+++ b/subcommand/config_test.go
@@ -2,6 +2,7 @@ package subcommand
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -214,7 +215,7 @@ const testConfigJSON = `{
 func TestLoadConfigFromDir(t *testing.T) {
 	t.Run("config only (no macros.json)", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.WriteFile(dir+"/config.json", []byte(testConfigJSON), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(testConfigJSON), 0600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -232,11 +233,11 @@ func TestLoadConfigFromDir(t *testing.T) {
 
 	t.Run("with valid macros.json", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.WriteFile(dir+"/config.json", []byte(testConfigJSON), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(testConfigJSON), 0600); err != nil {
 			t.Fatal(err)
 		}
 		macrosJSON := `[{"name": "test macro", "description": "test", "ignore_error": true, "actions": [{"type": "owntone_pause"}]}]`
-		if err := os.WriteFile(dir+"/macros.json", []byte(macrosJSON), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "macros.json"), []byte(macrosJSON), 0600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -266,10 +267,10 @@ func TestLoadConfigFromDir(t *testing.T) {
 
 	t.Run("invalid macros.json", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.WriteFile(dir+"/config.json", []byte(testConfigJSON), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(testConfigJSON), 0600); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(dir+"/macros.json", []byte(`[{invalid}]`), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "macros.json"), []byte(`[{invalid}]`), 0600); err != nil {
 			t.Fatal(err)
 		}
 		_, err := LoadConfigFromDir(dir)


### PR DESCRIPTION
## Summary
- replace string-concatenated paths in subcommand/config_test.go
- use ilepath.Join(dir, ...) for config.json and macros.json
- add path/filepath import

## Testing
- go test ./subcommand
- go test ./...

Closes #126