### PR TITLE
Handle macro action build failures explicitly

### DIFF
--- a/subcommand/action/error.go
+++ b/subcommand/action/error.go
@@ -1,0 +1,24 @@
+package action
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+)
+
+// ErrorAction always returns the configured error when executed.
+type ErrorAction struct {
+	err error
+}
+
+// Run executes the ErrorAction and returns the configured error.
+func (a ErrorAction) Run(ctx context.Context, _ string) (string, error) {
+	_, span := otel.Tracer("action").Start(ctx, "ErrorAction.Run")
+	defer span.End()
+	return "", a.err
+}
+
+// NewErrorAction creates a new ErrorAction.
+func NewErrorAction(err error) ErrorAction {
+	return ErrorAction{err: err}
+}

--- a/subcommand/action/error_test.go
+++ b/subcommand/action/error_test.go
@@ -1,0 +1,22 @@
+package action
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorAction_Run(t *testing.T) {
+	wantErr := errors.New("boom")
+	a := NewErrorAction(wantErr)
+
+	msg, err := a.Run(t.Context(), "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
+	}
+	if msg != "" {
+		t.Fatalf("expected empty message, got %q", msg)
+	}
+}

--- a/subcommand/config_test.go
+++ b/subcommand/config_test.go
@@ -1,6 +1,7 @@
 package subcommand
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -290,6 +291,38 @@ func TestLoadConfigFromDir(t *testing.T) {
 		}
 		if !found {
 			t.Error("macro 'test macro' should be registered as a command")
+		}
+	})
+
+	t.Run("macro action build failure returns explicit runtime error", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(testConfigJSON), 0600); err != nil {
+			t.Fatal(err)
+		}
+		macrosJSON := `[{"name":"broken macro","description":"broken","ignore_error":true,"actions":[{"type":"wait","params":{"seconds":"abc"}}]}]`
+		if err := os.WriteFile(filepath.Join(dir, "macros.json"), []byte(macrosJSON), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := LoadConfigFromDir(dir)
+		if err != nil {
+			t.Fatalf("LoadConfigFromDir failed: %v", err)
+		}
+
+		def, args, _, err := config.Commands.Find(context.Background(), config, "broken macro")
+		if err != nil {
+			t.Fatalf("Find failed: %v", err)
+		}
+
+		_, err = def.Init(config).Exec(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected execution error for broken macro")
+		}
+		if !strings.Contains(err.Error(), `macro "broken macro" initialization failed`) {
+			t.Fatalf("expected macro initialization error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), `invalid seconds "abc"`) {
+			t.Fatalf("expected root cause in error, got %v", err)
 		}
 	})
 

--- a/subcommand/macro.go
+++ b/subcommand/macro.go
@@ -71,7 +71,13 @@ func newMacroDefinition(macro MacroConfig) Definition {
 		Factory: func(def Definition, config Config) Subcommand {
 			actions, err := buildActionsFromSpecs(macro.Actions, config)
 			if err != nil {
-				slog.Error("failed to build macro actions", "macro", macro.Name, "error", err)
+				buildErr := fmt.Errorf("macro %q initialization failed: %w", macro.Name, err)
+				slog.Error("failed to build macro actions", "macro", macro.Name, "error", buildErr)
+				return Subcommand{
+					Definition:  def,
+					actions:     []action.Action{action.NewErrorAction(buildErr)},
+					ignoreError: false,
+				}
 			}
 			return Subcommand{
 				Definition:  def,

--- a/subcommand/macro_test.go
+++ b/subcommand/macro_test.go
@@ -1,6 +1,7 @@
 package subcommand
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/johtani/smarthome/subcommand/action/owntone"
@@ -88,6 +89,36 @@ func TestValidateMacros(t *testing.T) {
 				t.Errorf("validateMacros() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestNewMacroDefinition_BuildFailureReturnsExplicitError(t *testing.T) {
+	config := Config{
+		Owntone:   owntone.Config{URL: "http://localhost:8000"},
+		Yamaha:    yamaha.Config{URL: "http://localhost:8080"},
+		Switchbot: switchbot.Config{Token: "token", Secret: "secret"},
+	}
+	macro := MacroConfig{
+		Name:        "broken macro",
+		Description: "broken",
+		IgnoreError: true,
+		Actions: []ActionSpec{
+			{Type: "wait", Params: map[string]string{"seconds": "abc"}},
+		},
+	}
+
+	def := newMacroDefinition(macro)
+	cmd := def.Init(config)
+
+	_, err := cmd.Exec(t.Context(), "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `macro "broken macro" initialization failed`) {
+		t.Fatalf("expected macro initialization error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), `invalid seconds "abc"`) {
+		t.Fatalf("expected root cause in error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 概要
- マクロのアクション構築に失敗した場合、空/欠落したコマンドとして実行されないように修正しました
- 失敗時は実行時に原因付きの明示エラーを返すようにしました
- マクロ読み込み経路を含む失敗ケースのテストを追加しました

## 変更内容
- `subcommand/macro.go`
  - `buildActionsFromSpecs` 失敗時に `ErrorAction` を1つ持つ `Subcommand` を返すよう変更
  - エラーメッセージは `macro "<name>" initialization failed: ...` 形式
  - 初期化失敗時は `ignore_error` を無効化し、失敗を握りつぶさない
- `subcommand/action/error.go`
  - 常にエラーを返す `ErrorAction` を追加
- `subcommand/action/error_test.go`
  - `ErrorAction` の単体テストを追加
- `subcommand/macro_test.go`
  - マクロ構築失敗時に明示エラーとなるテストを追加
- `subcommand/config_test.go`
  - `LoadConfigFromDir` 経由で壊れたマクロ実行時に原因付きエラーを返すテストを追加

## 動作確認
- `go test ./...`

## 補足
- `golangci-lint run` はローカル環境のツールチェーン差異で失敗
  - `golangci-lint` のビルド Go: `go1.24`
  - プロジェクト対象 Go: `1.25.8`

Closes #142
