### PR TITLE
タイポ修正: 命名ゆれ(Palylist/Subcommnad/Smrat)を統一

### DIFF
--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -34,7 +34,7 @@ func Run(configStore *configstore.Store) error {
 // NewMCPServer creates and returns a new MCPServer instance.
 func NewMCPServer() *server.MCPServer {
 	return server.NewMCPServer(
-		"Smrat Home MCP",
+		"Smart Home MCP",
 		"0.1.0",
 		server.WithLogging(),
 	)

--- a/subcommand/display-palylists.go
+++ b/subcommand/display-palylists.go
@@ -11,18 +11,18 @@ const DisplayPlaylistsCmd = "display playlist"
 // DispPlaylistsCmd is a short name for the display playlists command.
 const DispPlaylistsCmd = "disp playlists"
 
-// NewDisplayPalylistCmdDefinition creates the definition for the display playlists command.
-func NewDisplayPalylistCmdDefinition() Definition {
+// NewDisplayPlaylistCmdDefinition creates the definition for the display playlists command.
+func NewDisplayPlaylistCmdDefinition() Definition {
 	return Definition{
 		Name:        DisplayPlaylistsCmd,
 		shortnames:  []string{DispPlaylistsCmd},
 		Description: "Display playlists",
-		Factory:     NewDisplayPalylistsSubcommand,
+		Factory:     NewDisplayPlaylistsSubcommand,
 	}
 }
 
-// NewDisplayPalylistsSubcommand creates a new Subcommand for the display playlists command.
-func NewDisplayPalylistsSubcommand(definition Definition, config Config) Subcommand {
+// NewDisplayPlaylistsSubcommand creates a new Subcommand for the display playlists command.
+func NewDisplayPlaylistsSubcommand(definition Definition, config Config) Subcommand {
 	owntoneClient := owntone.NewClient(config.Owntone)
 	return Subcommand{
 		Definition: definition,

--- a/subcommand/display-temperature.go
+++ b/subcommand/display-temperature.go
@@ -16,13 +16,13 @@ func NewDisplayTemperatureDefinition() Definition {
 	return Definition{
 		Name:        DisplayTemperatureCmd,
 		Description: "Display temperature/humidity",
-		Factory:     NewDisplayTemperatureSubcommnad,
+		Factory:     NewDisplayTemperatureSubcommand,
 		shortnames:  []string{DispTempCmd},
 	}
 }
 
-// NewDisplayTemperatureSubcommnad creates a new Subcommand for the display temperature command.
-func NewDisplayTemperatureSubcommnad(definition Definition, config Config) Subcommand {
+// NewDisplayTemperatureSubcommand creates a new Subcommand for the display temperature command.
+func NewDisplayTemperatureSubcommand(definition Definition, config Config) Subcommand {
 	switchbotClient := switchbot.NewClient(config.Switchbot)
 	return Subcommand{
 		Definition: definition,

--- a/subcommand/subcommand.go
+++ b/subcommand/subcommand.go
@@ -204,7 +204,7 @@ func NewCommands(macros ...MacroConfig) Commands {
 		NewPlayRandomGenreCmdDefinition(),
 		NewStopMusicDefinition(),
 		NewChangePlaylistCmdDefinition(),
-		NewDisplayPalylistCmdDefinition(),
+		NewDisplayPlaylistCmdDefinition(),
 		NewDisplayOutputsCmdDefinition(),
 		NewUpdateLibraryCmdDefinition(),
 		NewSearchMusicCmdDefinition(),


### PR DESCRIPTION
## 概要
Issue #143 のタイポ修正を実施しました。

## 変更内容
- NewDisplayPalylistCmdDefinition -> NewDisplayPlaylistCmdDefinition
- NewDisplayPalylistsSubcommand -> NewDisplayPlaylistsSubcommand
- NewDisplayTemperatureSubcommnad -> NewDisplayTemperatureSubcommand
- 参照箇所（subcommand/subcommand.go）を追従修正
- MCP サーバー名 Smrat Home MCP -> Smart Home MCP

## 確認
- gofmt -w 実行済み
- go test ./... 成功
- golangci-lint run はローカル環境の Go バージョン不整合で実行不可
  - lint binary: go1.24
  - target Go: 1.25.8

Closes #143