### PR TITLE
Action.Run spanにaction.argsを追加してトレース共通化

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,3 +27,9 @@
 2. 入力（CLI/Slack/MCP）をサブコマンドに解決する
 3. サブコマンドが複数 Action を順次実行する
 4. 実行結果を呼び出し元へ返す
+
+## Action のトレース方針
+
+- `Action.Run` のスパン作成は `subcommand/action.StartRunSpan` を使って共通化する
+- `StartRunSpan` は `action.args` 属性を付与する
+- 新しい Action を追加するときは、`otel.Tracer(...).Start(...)` を直接呼ばずに `StartRunSpan` を使う

--- a/subcommand/action/action.go
+++ b/subcommand/action/action.go
@@ -4,9 +4,22 @@ Actions are the smallest units of work, such as calling an API or controlling a 
 */
 package action
 
-import "context"
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
 
 // Action is an interface for executing a single smart home action.
 type Action interface {
 	Run(ctx context.Context, args string) (string, error)
+}
+
+// StartRunSpan starts an action run span with common trace attributes.
+func StartRunSpan(ctx context.Context, tracerName, spanName, args string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, spanName, trace.WithAttributes(
+		attribute.String("action.args", args),
+	))
 }

--- a/subcommand/action/error.go
+++ b/subcommand/action/error.go
@@ -2,8 +2,6 @@ package action
 
 import (
 	"context"
-
-	"go.opentelemetry.io/otel"
 )
 
 // ErrorAction always returns the configured error when executed.
@@ -12,8 +10,8 @@ type ErrorAction struct {
 }
 
 // Run executes the ErrorAction and returns the configured error.
-func (a ErrorAction) Run(ctx context.Context, _ string) (string, error) {
-	_, span := otel.Tracer("action").Start(ctx, "ErrorAction.Run")
+func (a ErrorAction) Run(ctx context.Context, args string) (string, error) {
+	_, span := StartRunSpan(ctx, "action", "ErrorAction.Run", args)
 	defer span.End()
 	return "", a.err
 }

--- a/subcommand/action/fixed-args.go
+++ b/subcommand/action/fixed-args.go
@@ -9,7 +9,7 @@ type FixedArgsAction struct {
 }
 
 // Run executes the wrapped action with fixed args.
-func (a FixedArgsAction) Run(ctx context.Context, _ string) (string, error) {
+func (a FixedArgsAction) Run(ctx context.Context, args string) (string, error) {
 	return a.action.Run(ctx, a.args)
 }
 

--- a/subcommand/action/healthcheck/healthcheck.go
+++ b/subcommand/action/healthcheck/healthcheck.go
@@ -6,10 +6,10 @@ package healthcheck
 import (
 	"context"
 
+	"github.com/johtani/smarthome/subcommand/action"
 	"github.com/johtani/smarthome/subcommand/action/owntone"
 	"github.com/johtani/smarthome/subcommand/action/switchbot"
 	"github.com/johtani/smarthome/subcommand/action/yamaha"
-	"go.opentelemetry.io/otel"
 )
 
 // SwitchBotHealthCheckAction checks the health of the SwitchBot API.
@@ -18,8 +18,8 @@ type SwitchBotHealthCheckAction struct {
 }
 
 // Run executes the SwitchBotHealthCheckAction.
-func (a SwitchBotHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("healthcheck").Start(ctx, "SwitchBotHealthCheckAction.Run")
+func (a SwitchBotHealthCheckAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "healthcheck", "SwitchBotHealthCheckAction.Run", args)
 	defer span.End()
 	_, _, err := a.client.DeviceAPI.List(ctx)
 	if err != nil {
@@ -39,8 +39,8 @@ type OwnToneHealthCheckAction struct {
 }
 
 // Run executes the OwnToneHealthCheckAction.
-func (a OwnToneHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("healthcheck").Start(ctx, "OwnToneHealthCheckAction.Run")
+func (a OwnToneHealthCheckAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "healthcheck", "OwnToneHealthCheckAction.Run", args)
 	defer span.End()
 	_, err := a.client.Counts(ctx)
 	if err != nil {
@@ -60,8 +60,8 @@ type YamahaHealthCheckAction struct {
 }
 
 // Run executes the YamahaHealthCheckAction.
-func (a YamahaHealthCheckAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("healthcheck").Start(ctx, "YamahaHealthCheckAction.Run")
+func (a YamahaHealthCheckAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "healthcheck", "YamahaHealthCheckAction.Run", args)
 	defer span.End()
 	err := a.client.GetDeviceInfo(ctx)
 	if err != nil {

--- a/subcommand/action/help.go
+++ b/subcommand/action/help.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"context"
-	"go.opentelemetry.io/otel"
 )
 
 // HelpAction represents an action that displays the help message.
@@ -11,8 +10,8 @@ type HelpAction struct {
 }
 
 // Run executes the HelpAction by returning the help string.
-func (a HelpAction) Run(ctx context.Context, _ string) (string, error) {
-	_, span := otel.Tracer("action").Start(ctx, "HelpAction.Run")
+func (a HelpAction) Run(ctx context.Context, args string) (string, error) {
+	_, span := StartRunSpan(ctx, "action", "HelpAction.Run", args)
 	defer span.End()
 	return a.help, nil
 }

--- a/subcommand/action/kagome/kagome.go
+++ b/subcommand/action/kagome/kagome.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ikawaha/kagome/v2/tokenizer"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // Dict represents the type of dictionary used by Kagome.
@@ -39,7 +39,7 @@ type Action struct {
 
 // Run executes the Kagome tokenization action.
 func (a Action) Run(ctx context.Context, args string) (string, error) {
-	_, span := otel.Tracer("kagome").Start(ctx, "Action.Run")
+	_, span := action.StartRunSpan(ctx, "kagome", "Action.Run", args)
 	defer span.End()
 	var dict *dict.Dict
 	switch a.dictionary {

--- a/subcommand/action/noop.go
+++ b/subcommand/action/noop.go
@@ -3,7 +3,6 @@ package action
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
 	"time"
 )
 
@@ -13,8 +12,8 @@ type NoOpAction struct {
 }
 
 // Run executes the NoOpAction by sleeping for the specified interval.
-func (a NoOpAction) Run(ctx context.Context, _ string) (string, error) {
-	_, span := otel.Tracer("action").Start(ctx, "NoOpAction.Run")
+func (a NoOpAction) Run(ctx context.Context, args string) (string, error) {
+	_, span := StartRunSpan(ctx, "action", "NoOpAction.Run", args)
 	defer span.End()
 	time.Sleep(a.interval)
 	return fmt.Sprintf("Paused for %v", a.interval), nil

--- a/subcommand/action/owntone/change-playlist.go
+++ b/subcommand/action/owntone/change-playlist.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // ChangePlaylistAction represents an action to change the current playlist on Owntone.
@@ -19,8 +19,8 @@ type ChangePlaylistAction struct {
 
 // Run executes the ChangePlaylistAction.
 // It picks a random playlist and starts playback.
-func (a ChangePlaylistAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "ChangePlaylistAction.Run")
+func (a ChangePlaylistAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "owntone", "ChangePlaylistAction.Run", args)
 	defer span.End()
 	msg := []string{"Change playlist to"}
 	playlists, err := a.c.GetPlaylists(ctx)

--- a/subcommand/action/owntone/clear-queue.go
+++ b/subcommand/action/owntone/clear-queue.go
@@ -3,7 +3,7 @@ package owntone
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // ClearQueueAction represents an action to clear the playback queue on Owntone.
@@ -13,8 +13,8 @@ type ClearQueueAction struct {
 }
 
 // Run executes the ClearQueueAction.
-func (a ClearQueueAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "ClearQueueAction.Run")
+func (a ClearQueueAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "owntone", "ClearQueueAction.Run", args)
 	defer span.End()
 	err := a.c.ClearQueue(ctx)
 	if err != nil {

--- a/subcommand/action/owntone/outputs.go
+++ b/subcommand/action/owntone/outputs.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // DisplayOutputsAction lists Owntone outputs ordered by Selected=true first, then false.
@@ -33,8 +33,8 @@ func NewDisplayOutputsAction(client *Client, opts ...bool) DisplayOutputsAction 
 }
 
 // Run fetches outputs and returns a formatted string.
-func (a DisplayOutputsAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "DisplayOutputsAction.Run")
+func (a DisplayOutputsAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "owntone", "DisplayOutputsAction.Run", args)
 	defer span.End()
 	outputs, err := a.c.GetOutputs(ctx)
 	if err != nil {

--- a/subcommand/action/owntone/pause.go
+++ b/subcommand/action/owntone/pause.go
@@ -2,7 +2,7 @@ package owntone
 
 import (
 	"context"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // PauseAction represents an action to pause playback on Owntone.
@@ -12,8 +12,8 @@ type PauseAction struct {
 }
 
 // Run executes the PauseAction.
-func (a PauseAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "PauseAction.Run")
+func (a PauseAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "owntone", "PauseAction.Run", args)
 	defer span.End()
 	err := a.c.Pause(ctx)
 	if err != nil {

--- a/subcommand/action/owntone/play.go
+++ b/subcommand/action/owntone/play.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // PlayAction represents an action to play music on Owntone.
@@ -22,7 +22,7 @@ type PlayAction struct {
 // Run executes the PlayAction.
 // It can play a random artist, random genre, or a random playlist depending on args.
 func (a PlayAction) Run(ctx context.Context, args string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "PlayAction.Run")
+	ctx, span := action.StartRunSpan(ctx, "owntone", "PlayAction.Run", args)
 	defer span.End()
 	switch {
 	case strings.HasPrefix(args, "artist"):

--- a/subcommand/action/owntone/playlists.go
+++ b/subcommand/action/owntone/playlists.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // DisplayPlaylistsAction represents an action to displayplaylists from Owntone.
@@ -16,7 +16,7 @@ type DisplayPlaylistsAction struct {
 
 // Run executes the DisplayPlaylistsAction and returns a formatted string of playlists.
 func (a DisplayPlaylistsAction) Run(ctx context.Context, category string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "DisplayPlaylistsAction.Run")
+	ctx, span := action.StartRunSpan(ctx, "owntone", "DisplayPlaylistsAction.Run", category)
 	defer span.End()
 	msg := []string{"Playlists are..."}
 	flg := onlySpotify(category)

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // SearchAndPlayAction represents an action to search for music and play it on Owntone.
@@ -27,7 +27,7 @@ func appendMessage(items Items, label string, msg []string, uris []string, loopF
 
 // Run executes the SearchAndPlayAction.
 func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "SearchAndPlayAction.Run")
+	ctx, span := action.StartRunSpan(ctx, "owntone", "SearchAndPlayAction.Run", query)
 	defer span.End()
 	msg := []string{"Search Results..."}
 	searchQuery := Parse(query)
@@ -101,7 +101,7 @@ type SearchAndDisplayAction struct {
 
 // Run executes the SearchAndDisplayAction.
 func (a SearchAndDisplayAction) Run(ctx context.Context, query string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "SearchAndDisplayAction.Run")
+	ctx, span := action.StartRunSpan(ctx, "owntone", "SearchAndDisplayAction.Run", query)
 	defer span.End()
 	msg := []string{"Search Results..."}
 	// fmt.Println("original query... " + query)

--- a/subcommand/action/owntone/update-library.go
+++ b/subcommand/action/owntone/update-library.go
@@ -3,7 +3,7 @@ package owntone
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // UpdateLibraryAction represents an action to update the Owntone library.
@@ -13,8 +13,8 @@ type UpdateLibraryAction struct {
 }
 
 // Run executes the UpdateLibraryAction.
-func (a UpdateLibraryAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("owntone").Start(ctx, "UpdateLibraryAction.Run")
+func (a UpdateLibraryAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "owntone", "UpdateLibraryAction.Run", args)
 	defer span.End()
 	err := a.c.UpdateLibrary(ctx)
 	if err != nil {

--- a/subcommand/action/switchbot/execute-scene.go
+++ b/subcommand/action/switchbot/execute-scene.go
@@ -3,7 +3,7 @@ package switchbot
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // ExecuteSceneAction represents an action to execute a SwitchBot scene.
@@ -14,8 +14,8 @@ type ExecuteSceneAction struct {
 }
 
 // Run executes the ExecuteSceneAction.
-func (a ExecuteSceneAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("switchbot").Start(ctx, "ExecuteSceneAction.Run")
+func (a ExecuteSceneAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "switchbot", "ExecuteSceneAction.Run", args)
 	defer span.End()
 	err := a.client.Execute(ctx, a.sceneID)
 	if err != nil {

--- a/subcommand/action/switchbot/get-temperature-humidity.go
+++ b/subcommand/action/switchbot/get-temperature-humidity.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // DefaultDeviceTypes is the default list of device types for which temperature and humidity are fetched.
@@ -20,8 +20,8 @@ type GetTemperatureAndHumidityAction struct {
 }
 
 // Run executes the GetTemperatureAndHumidityAction.
-func (a GetTemperatureAndHumidityAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("switchbot").Start(ctx, "GetTemperatureAndHumidityAction.Run")
+func (a GetTemperatureAndHumidityAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "switchbot", "GetTemperatureAndHumidityAction.Run", args)
 	defer span.End()
 	msg := map[string]string{}
 	//goland:noinspection SpellCheckingInspection

--- a/subcommand/action/switchbot/list-devices.go
+++ b/subcommand/action/switchbot/list-devices.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // ListDevicesAction represents an action to list all SwitchBot devices.
@@ -15,8 +15,8 @@ type ListDevicesAction struct {
 }
 
 // Run executes the ListDevicesAction.
-func (a ListDevicesAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("switchbot").Start(ctx, "ListDevicesAction.Run")
+func (a ListDevicesAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "switchbot", "ListDevicesAction.Run", args)
 	defer span.End()
 	var msg []string
 	pdev, vdev, err := a.client.DeviceAPI.List(ctx)

--- a/subcommand/action/switchbot/list-scenes.go
+++ b/subcommand/action/switchbot/list-scenes.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // ListScenesAction represents an action to list all SwitchBot scenes.
@@ -15,8 +15,8 @@ type ListScenesAction struct {
 }
 
 // Run executes the ListScenesAction.
-func (a ListScenesAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("switchbot").Start(ctx, "ListScenesAction.Run")
+func (a ListScenesAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "switchbot", "ListScenesAction.Run", args)
 	defer span.End()
 	scenes, err := a.client.SceneAPI.List(ctx)
 	var msg []string

--- a/subcommand/action/switchbot/send-command.go
+++ b/subcommand/action/switchbot/send-command.go
@@ -3,8 +3,8 @@ package switchbot
 import (
 	"context"
 	"fmt"
+	"github.com/johtani/smarthome/subcommand/action"
 	"github.com/nasa9084/go-switchbot/v3"
-	"go.opentelemetry.io/otel"
 )
 
 // SendCommandAction represents an action to send a command to a SwitchBot device.
@@ -16,8 +16,8 @@ type SendCommandAction struct {
 }
 
 // Run executes the SendCommandAction.
-func (a SendCommandAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("switchbot").Start(ctx, "SendCommandAction.Run")
+func (a SendCommandAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "switchbot", "SendCommandAction.Run", args)
 	defer span.End()
 	err := a.client.Command(ctx, a.deviceID, a.command)
 	if err != nil {

--- a/subcommand/action/yamaha/power-off.go
+++ b/subcommand/action/yamaha/power-off.go
@@ -2,7 +2,7 @@ package yamaha
 
 import (
 	"context"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // PowerOffAction represents an action to turn off the Yamaha device.
@@ -12,8 +12,8 @@ type PowerOffAction struct {
 }
 
 // Run executes the PowerOffAction.
-func (a PowerOffAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("yamaha").Start(ctx, "PowerOffAction.Run")
+func (a PowerOffAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "yamaha", "PowerOffAction.Run", args)
 	defer span.End()
 	err := a.c.PowerOff(ctx)
 	if err != nil {

--- a/subcommand/action/yamaha/power-on.go
+++ b/subcommand/action/yamaha/power-on.go
@@ -3,7 +3,7 @@ package yamaha
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // PowerOnAction represents an action to turn on the Yamaha device.
@@ -13,8 +13,8 @@ type PowerOnAction struct {
 }
 
 // Run executes the PowerOnAction.
-func (a PowerOnAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("yamaha").Start(ctx, "PowerOnAction.Run")
+func (a PowerOnAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "yamaha", "PowerOnAction.Run", args)
 	defer span.End()
 	err := a.c.PowerOn(ctx)
 	if err != nil {

--- a/subcommand/action/yamaha/set-input.go
+++ b/subcommand/action/yamaha/set-input.go
@@ -3,7 +3,7 @@ package yamaha
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // SetInputAction represents an action to set the input source on the Yamaha device.
@@ -14,8 +14,8 @@ type SetInputAction struct {
 }
 
 // Run executes the SetInputAction.
-func (a SetInputAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("yamaha").Start(ctx, "SetInputAction.Run")
+func (a SetInputAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "yamaha", "SetInputAction.Run", args)
 	defer span.End()
 	err := a.c.SetInput(ctx, a.input)
 	if err != nil {

--- a/subcommand/action/yamaha/set-scene.go
+++ b/subcommand/action/yamaha/set-scene.go
@@ -3,7 +3,7 @@ package yamaha
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // SetSceneAction represents an action to set the scene on the Yamaha device.
@@ -14,8 +14,8 @@ type SetSceneAction struct {
 }
 
 // Run executes the SetSceneAction.
-func (a SetSceneAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("yamaha").Start(ctx, "SetSceneAction.Run")
+func (a SetSceneAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "yamaha", "SetSceneAction.Run", args)
 	defer span.End()
 	err := a.c.SetScene(ctx, a.scene)
 	if err != nil {

--- a/subcommand/action/yamaha/set-volume.go
+++ b/subcommand/action/yamaha/set-volume.go
@@ -3,7 +3,7 @@ package yamaha
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	"github.com/johtani/smarthome/subcommand/action"
 )
 
 // SetVolumeAction represents an action to set the volume on the Yamaha device.
@@ -14,8 +14,8 @@ type SetVolumeAction struct {
 }
 
 // Run executes the SetVolumeAction.
-func (a SetVolumeAction) Run(ctx context.Context, _ string) (string, error) {
-	ctx, span := otel.Tracer("yamaha").Start(ctx, "SetVolumeAction.Run")
+func (a SetVolumeAction) Run(ctx context.Context, args string) (string, error) {
+	ctx, span := action.StartRunSpan(ctx, "yamaha", "SetVolumeAction.Run", args)
 	defer span.End()
 	err := a.c.SetVolume(ctx, a.volume)
 	if err != nil {

--- a/subcommand/tracing_test.go
+++ b/subcommand/tracing_test.go
@@ -51,3 +51,41 @@ func TestSubcommand_Exec_Tracing(t *testing.T) {
 		t.Error("expected 'Subcommand.Exec' span to be recorded, but not found")
 	}
 }
+
+func TestSubcommand_Exec_TracingActionArgsWithFixedArgs(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(trace.AlwaysSample()),
+		trace.WithSyncer(exporter),
+	)
+	otel.SetTracerProvider(tp)
+
+	s := Subcommand{
+		Definition: Definition{
+			Name:        "test",
+			Description: "test",
+		},
+		actions: []action.Action{
+			action.NewFixedArgsAction(action.NewHelpAction("ok"), "fixed-arg"),
+		},
+	}
+
+	if _, err := s.Exec(context.Background(), "original-arg"); err != nil {
+		t.Fatalf("Exec() failed: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	for _, span := range spans {
+		if span.Name != "HelpAction.Run" {
+			continue
+		}
+		for _, attr := range span.Attributes {
+			if string(attr.Key) == "action.args" && attr.Value.AsString() == "fixed-arg" {
+				return
+			}
+		}
+		t.Fatalf("expected HelpAction.Run span to include action.args=fixed-arg")
+	}
+
+	t.Fatalf("expected HelpAction.Run span to be recorded, but not found")
+}


### PR DESCRIPTION
## 概要
- `subcommand/action.StartRunSpan` を追加し、Action実行スパン生成を共通化
- `Action.Run` でスパンを生成している実装を共通ヘルパー経由へ統一
- 各Action実行スパンに `action.args` 属性を付与
- 新規Actionでの実装漏れ防止のため `docs/architecture.md` に方針を追記
- `FixedArgsAction` 経由時に固定引数が span に入ることを tracing test で検証

## テスト
- `go test ./subcommand/...`

Closes #153
