### PR TITLE
Display current commit hash in help output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/johtani/smarthome
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-co-op/gocron/v2 v2.12.1

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func TestRunCmd(t *testing.T) {
 		{
 			name:     "help command",
 			args:     []string{"help"},
-			wantCont: "利用可能なコマンドは次の通りです",
+			wantCont: "commit:",
 			wantErr:  false,
 		},
 		{

--- a/subcommand/buildinfo.go
+++ b/subcommand/buildinfo.go
@@ -1,0 +1,44 @@
+package subcommand
+
+import "runtime/debug"
+
+const (
+	unknownRevision  = "unknown"
+	revisionShortLen = 12
+)
+
+// currentRevision returns the current VCS revision from Go build info.
+// When unavailable, it falls back to "unknown".
+func currentRevision() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok || bi == nil {
+		return unknownRevision
+	}
+
+	return revisionFromBuildSettings(bi.Settings)
+}
+
+func revisionFromBuildSettings(settings []debug.BuildSetting) string {
+	revision := ""
+	modified := false
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return unknownRevision
+	}
+	if len(revision) > revisionShortLen {
+		revision = revision[:revisionShortLen]
+	}
+	if modified {
+		return revision + "-dirty"
+	}
+
+	return revision
+}

--- a/subcommand/buildinfo_test.go
+++ b/subcommand/buildinfo_test.go
@@ -1,0 +1,52 @@
+package subcommand
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestRevisionFromBuildSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		want     string
+	}{
+		{
+			name: "no revision falls back to unknown",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.time", Value: "2026-04-10T00:00:00Z"},
+			},
+			want: unknownRevision,
+		},
+		{
+			name: "short revision stays as is",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc1234"},
+			},
+			want: "abc1234",
+		},
+		{
+			name: "long revision is shortened",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "0123456789abcdef"},
+			},
+			want: "0123456789ab",
+		},
+		{
+			name: "dirty suffix is appended",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "0123456789abcdef"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: "0123456789ab-dirty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := revisionFromBuildSettings(tt.settings); got != tt.want {
+				t.Errorf("revisionFromBuildSettings() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/subcommand/help.go
+++ b/subcommand/help.go
@@ -1,6 +1,7 @@
 package subcommand
 
 import (
+	"fmt"
 	"github.com/johtani/smarthome/subcommand/action"
 )
 
@@ -18,10 +19,11 @@ func NewHelpDefinition() Definition {
 
 // NewHelpSubcommand creates a new Subcommand for the help command.
 func NewHelpSubcommand(definition Definition, config Config) Subcommand {
+	helpMessage := fmt.Sprintf("%scommit: %s\n", config.Commands.Help(), currentRevision())
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{
-			action.NewHelpAction(config.Commands.Help()),
+			action.NewHelpAction(helpMessage),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- append `commit: <revision>` to `smarthome help` output
- read revision from Go build info (`runtime/debug.ReadBuildInfo`, `vcs.revision`)
- fallback to `unknown` when unavailable, shorten long hash to 12 chars, append `-dirty` when `vcs.modified=true`
- add tests for build info parsing and update help command expectation in `main_test`

## Verification
- gofmt -w subcommand/help.go subcommand/buildinfo.go subcommand/buildinfo_test.go main_test.go
- go test ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run

Closes #155