### PR TITLE
Fix help build info fallback and restore header line

### DIFF
--- a/subcommand/buildinfo.go
+++ b/subcommand/buildinfo.go
@@ -1,21 +1,43 @@
 package subcommand
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"strings"
+)
 
 const (
 	unknownRevision  = "unknown"
 	revisionShortLen = 12
+	develVersion     = "(devel)"
 )
 
 // currentRevision returns the current VCS revision from Go build info.
-// When unavailable, it falls back to "unknown".
+// If unavailable, it falls back to module version, then "unknown".
 func currentRevision() string {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok || bi == nil {
 		return unknownRevision
 	}
 
-	return revisionFromBuildSettings(bi.Settings)
+	return revisionOrVersion(bi)
+}
+
+func revisionOrVersion(bi *debug.BuildInfo) string {
+	revision := revisionFromBuildSettings(bi.Settings)
+	if revision != unknownRevision {
+		return revision
+	}
+
+	return versionFromBuildInfo(bi)
+}
+
+func versionFromBuildInfo(bi *debug.BuildInfo) string {
+	version := strings.TrimSpace(bi.Main.Version)
+	if version == "" || version == develVersion {
+		return unknownRevision
+	}
+
+	return version
 }
 
 func revisionFromBuildSettings(settings []debug.BuildSetting) string {

--- a/subcommand/buildinfo_test.go
+++ b/subcommand/buildinfo_test.go
@@ -50,3 +50,50 @@ func TestRevisionFromBuildSettings(t *testing.T) {
 		})
 	}
 }
+
+func TestRevisionOrVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "uses vcs revision when available",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v9.9.9"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "0123456789abcdef"},
+				},
+			},
+			want: "0123456789ab",
+		},
+		{
+			name: "falls back to main version when revision is unavailable",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v1.2.3"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.time", Value: "2026-04-10T00:00:00Z"},
+				},
+			},
+			want: "v1.2.3",
+		},
+		{
+			name: "returns unknown when main version is devel",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: develVersion},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.time", Value: "2026-04-10T00:00:00Z"},
+				},
+			},
+			want: unknownRevision,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := revisionOrVersion(tt.info); got != tt.want {
+				t.Errorf("revisionOrVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/subcommand/help.go
+++ b/subcommand/help.go
@@ -19,7 +19,7 @@ func NewHelpDefinition() Definition {
 
 // NewHelpSubcommand creates a new Subcommand for the help command.
 func NewHelpSubcommand(definition Definition, config Config) Subcommand {
-	helpMessage := fmt.Sprintf("%scommit: %s\n", config.Commands.Help(), currentRevision())
+	helpMessage := fmt.Sprintf("利用可能なコマンドは次の通りです\n%scommit: %s\n", config.Commands.Help(), currentRevision())
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{

--- a/subcommand/help_test.go
+++ b/subcommand/help_test.go
@@ -1,0 +1,38 @@
+package subcommand
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestNewHelpSubcommand(t *testing.T) {
+	config := Config{
+		Commands: Commands{
+			Definitions: []Definition{
+				{
+					Name:        "sample",
+					Description: "sample description",
+					Factory:     NewDummySubcommand,
+				},
+			},
+		},
+	}
+
+	sub := NewHelpSubcommand(NewHelpDefinition(), config)
+
+	got, err := sub.Exec(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+
+	if !strings.HasPrefix(got, "利用可能なコマンドは次の通りです\n") {
+		t.Fatalf("help should start with guidance line, got: %q", got)
+	}
+	if !strings.Contains(got, "  sample : sample description\n") {
+		t.Fatalf("help should include command list, got: %q", got)
+	}
+	if !strings.Contains(got, "commit: ") {
+		t.Fatalf("help should include commit/version info, got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add build info fallback order for help output: `vcs.revision` -> `Main.Version` -> `unknown`
- exclude `(devel)` and empty module version from fallback target
- restore help first line: `利用可能なコマンドは次の通りです`
- add tests for revision/version fallback and help header rendering

## Verification
- gofmt -w subcommand/buildinfo.go subcommand/buildinfo_test.go subcommand/help.go subcommand/help_test.go
- go test ./... (pass)
- golangci-lint run (failed in local env: golangci-lint built with go1.24, target is go1.25.9)

Closes #157
