### PR TITLE
Collect unresolved feedback for resolver and DSPy dataset

### DIFF
--- a/internal/resolver/events.go
+++ b/internal/resolver/events.go
@@ -42,6 +42,7 @@ type FeedbackRecord struct {
 	FeedbackCorrection string
 	ResolvedCommand    string
 	ResolvedArgs       string
+	ResolverPathHint   string
 }
 
 // RecordDecision records a resolver decision event with a fixed schema.
@@ -104,6 +105,7 @@ func RecordFeedback(ctx context.Context, record FeedbackRecord) {
 		attribute.String("feedback.correction", record.FeedbackCorrection),
 		attribute.String("resolver.resolved_command", record.ResolvedCommand),
 		attribute.String("resolver.resolved_args", record.ResolvedArgs),
+		attribute.String("resolver.path_hint", record.ResolverPathHint),
 	)
 	span := trace.SpanFromContext(ctx)
 	span.AddEvent(eventNameFeedback, trace.WithAttributes(attrs...))
@@ -116,6 +118,7 @@ func RecordFeedback(ctx context.Context, record FeedbackRecord) {
 		"feedback.correction", record.FeedbackCorrection,
 		"resolver.resolved_command", record.ResolvedCommand,
 		"resolver.resolved_args", record.ResolvedArgs,
+		"resolver.path_hint", record.ResolverPathHint,
 	)
 }
 

--- a/internal/resolver/events_test.go
+++ b/internal/resolver/events_test.go
@@ -74,6 +74,7 @@ func TestRecordExecutionAndFeedbackAddsEvents(t *testing.T) {
 		FeedbackLabel:      "incorrect",
 		FeedbackCorrection: "light off",
 		ResolvedCommand:    "light on",
+		ResolverPathHint:   "unresolved",
 	})
 	span.End()
 
@@ -86,6 +87,10 @@ func TestRecordExecutionAndFeedbackAddsEvents(t *testing.T) {
 	}
 	if recorded.Events[1].Name != "resolver.feedback" {
 		t.Fatalf("expected second event resolver.feedback, got %q", recorded.Events[1].Name)
+	}
+	attrs := toMap(recorded.Events[1].Attributes)
+	if attrs["resolver.path_hint"] != "unresolved" {
+		t.Fatalf("expected resolver.path_hint unresolved, got %q", attrs["resolver.path_hint"])
 	}
 }
 

--- a/server/slack/feedback.go
+++ b/server/slack/feedback.go
@@ -28,13 +28,22 @@ type feedbackActionValue struct {
 	Label     string `json:"label"`
 	Command   string `json:"command"`
 	Args      string `json:"args"`
+	PathHint  string `json:"path_hint,omitempty"`
 }
 
 func buildResponseMessageOptions(feedbackEnabled bool, message, requestID, command, args string) []slack.MsgOption {
-	if !feedbackEnabled || strings.TrimSpace(command) == "" {
+	if !feedbackEnabled {
 		return []slack.MsgOption{slack.MsgOptionText(message, false)}
 	}
-	blocks, err := buildFeedbackBlocks(message, requestID, command, args)
+	var (
+		blocks []slack.Block
+		err    error
+	)
+	if strings.TrimSpace(command) == "" {
+		blocks, err = buildUnresolvedFeedbackBlocks(message, requestID)
+	} else {
+		blocks, err = buildFeedbackBlocks(message, requestID, command, args)
+	}
 	if err != nil {
 		slog.Warn("failed to build feedback blocks, fallback to plain text", "error", err)
 		return []slack.MsgOption{slack.MsgOptionText(message, false)}
@@ -87,6 +96,30 @@ func buildFeedbackBlocks(message, requestID, command, args string) ([]slack.Bloc
 	return []slack.Block{messageBlock, metaBlock, actions}, nil
 }
 
+func buildUnresolvedFeedbackBlocks(message, requestID string) ([]slack.Block, error) {
+	msgText := slack.NewTextBlockObject(slack.MarkdownType, message, false, false)
+	messageBlock := slack.NewSectionBlock(msgText, nil, nil)
+
+	metaText := slack.NewTextBlockObject(slack.MarkdownType, "解釈: `unresolved`", false, false)
+	metaBlock := slack.NewContextBlock("resolver_feedback_context", metaText)
+
+	teachValue, err := encodeFeedbackActionValue(feedbackActionValue{
+		RequestID: requestID,
+		Label:     "incorrect",
+		PathHint:  "unresolved",
+	})
+	if err != nil {
+		return nil, err
+	}
+	teachButton := slack.NewButtonBlockElement(
+		feedbackIncorrectActionID,
+		teachValue,
+		slack.NewTextBlockObject(slack.PlainTextType, "📝コマンドを教える", false, false),
+	)
+	actions := slack.NewActionBlock("resolver_feedback_actions", teachButton)
+	return []slack.Block{messageBlock, metaBlock, actions}, nil
+}
+
 func encodeFeedbackActionValue(v feedbackActionValue) (string, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -132,6 +165,7 @@ func newFeedbackBlockActionHandler() socketmode.SocketmodeHandlerFunc {
 			attribute.String("resolver.request_id", payload.RequestID),
 			attribute.String("resolver.resolved_command", payload.Command),
 			attribute.String("resolver.resolved_args", payload.Args),
+			attribute.String("resolver.path_hint", payload.PathHint),
 		)
 
 		if action.ActionID == feedbackCorrectActionID {
@@ -213,6 +247,7 @@ func newFeedbackViewSubmissionHandler() socketmode.SocketmodeHandlerFunc {
 			attribute.String("resolver.request_id", payload.RequestID),
 			attribute.String("resolver.resolved_command", payload.Command),
 			attribute.String("resolver.resolved_args", payload.Args),
+			attribute.String("resolver.path_hint", payload.PathHint),
 		)
 
 		recordFeedback(ctx, feedbackActionValue{
@@ -220,6 +255,7 @@ func newFeedbackViewSubmissionHandler() socketmode.SocketmodeHandlerFunc {
 			Label:     "incorrect",
 			Command:   payload.Command,
 			Args:      payload.Args,
+			PathHint:  payload.PathHint,
 		}, correction)
 	}
 }
@@ -248,11 +284,13 @@ func recordFeedback(ctx context.Context, payload feedbackActionValue, correction
 		attribute.String("feedback.correction", correction),
 		attribute.String("resolver.resolved_command", payload.Command),
 		attribute.String("resolver.resolved_args", payload.Args),
+		attribute.String("resolver.path_hint", payload.PathHint),
 	)
 	resolver.RecordFeedback(ctx, resolver.FeedbackRecord{
 		FeedbackLabel:      payload.Label,
 		FeedbackCorrection: correction,
 		ResolvedCommand:    payload.Command,
 		ResolvedArgs:       payload.Args,
+		ResolverPathHint:   payload.PathHint,
 	})
 }

--- a/server/slack/feedback_test.go
+++ b/server/slack/feedback_test.go
@@ -12,6 +12,7 @@ func TestFeedbackActionValueRoundTrip(t *testing.T) {
 		Label:     "correct",
 		Command:   "light on",
 		Args:      "",
+		PathHint:  "llm",
 	}
 	encoded, err := encodeFeedbackActionValue(in)
 	if err != nil {
@@ -61,6 +62,40 @@ func TestBuildFeedbackBlocks(t *testing.T) {
 	}
 }
 
+func TestBuildUnresolvedFeedbackBlocks(t *testing.T) {
+	blocks, err := buildUnresolvedFeedbackBlocks("sorry", "req-2")
+	if err != nil {
+		t.Fatalf("buildUnresolvedFeedbackBlocks failed: %v", err)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(blocks))
+	}
+
+	actionBlock, ok := blocks[2].(*slack.ActionBlock)
+	if !ok {
+		t.Fatalf("expected action block at index 2, got %T", blocks[2])
+	}
+	if len(actionBlock.Elements.ElementSet) != 1 {
+		t.Fatalf("expected 1 action element, got %d", len(actionBlock.Elements.ElementSet))
+	}
+
+	btnTeach, ok := actionBlock.Elements.ElementSet[0].(*slack.ButtonBlockElement)
+	if !ok {
+		t.Fatalf("expected button element, got %T", actionBlock.Elements.ElementSet[0])
+	}
+	if btnTeach.ActionID != feedbackIncorrectActionID {
+		t.Fatalf("expected action id %q, got %q", feedbackIncorrectActionID, btnTeach.ActionID)
+	}
+
+	payload, err := decodeFeedbackActionValue(btnTeach.Value)
+	if err != nil {
+		t.Fatalf("decode button payload failed: %v", err)
+	}
+	if payload.RequestID != "req-2" || payload.Label != "incorrect" || payload.PathHint != "unresolved" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
 func TestExtractCorrection(t *testing.T) {
 	state := &slack.ViewState{
 		Values: map[string]map[string]slack.BlockAction{
@@ -82,5 +117,12 @@ func TestBuildResponseMessageOptions_FeedbackDisabled(t *testing.T) {
 	options := buildResponseMessageOptions(false, "ok", "req-1", "light on", "")
 	if len(options) != 1 {
 		t.Fatalf("expected one msg option, got %d", len(options))
+	}
+}
+
+func TestBuildResponseMessageOptions_UnresolvedUsesBlocks(t *testing.T) {
+	options := buildResponseMessageOptions(true, "sorry", "req-1", "", "")
+	if len(options) != 2 {
+		t.Fatalf("expected two msg options, got %d", len(options))
 	}
 }

--- a/tools/dspy/prepare_dataset.py
+++ b/tools/dspy/prepare_dataset.py
@@ -26,8 +26,23 @@ def normalize(s: Optional[str]) -> str:
     return (s or "").strip()
 
 
+def split_correction_target(correction: str, known_commands: set[str]) -> tuple[str, str]:
+    text = normalize(correction)
+    if not text:
+        return "", ""
+
+    matches = [cmd for cmd in known_commands if text == cmd or text.startswith(cmd + " ")]
+    if matches:
+        cmd = max(matches, key=len)
+        return cmd, normalize(text[len(cmd):])
+
+    parts = text.split(maxsplit=1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
 def build_dataset_rows(csv_path: Path) -> List[dict]:
     grouped: Dict[str, RequestAggregate] = {}
+    known_commands: set[str] = set()
     with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
@@ -45,6 +60,8 @@ def build_dataset_rows(csv_path: Path) -> List[dict]:
             event_name = normalize(row.get("event_name"))
             command = normalize(row.get("resolver_resolved_command"))
             args = normalize(row.get("resolver_resolved_args"))
+            if command:
+                known_commands.add(command)
             if event_name in ("resolver.decision", "resolver.execution"):
                 if command:
                     agg.resolved_command = command
@@ -70,9 +87,7 @@ def build_dataset_rows(csv_path: Path) -> List[dict]:
 
         # If explicit negative feedback has correction, treat it as preferred target.
         if agg.feedback_label == "incorrect" and agg.feedback_correction:
-            parts = agg.feedback_correction.split(maxsplit=1)
-            expected_command = parts[0]
-            expected_args = parts[1] if len(parts) > 1 else ""
+            expected_command, expected_args = split_correction_target(agg.feedback_correction, known_commands)
 
         dataset.append(
             {

--- a/tools/dspy/prepare_dataset_test.py
+++ b/tools/dspy/prepare_dataset_test.py
@@ -1,0 +1,66 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from prepare_dataset import build_dataset_rows, split_correction_target
+
+
+class PrepareDatasetTest(unittest.TestCase):
+    def test_split_correction_target_prefers_longest_command_match(self) -> None:
+        cmd, args = split_correction_target(
+            "search and play 宇多田ヒカル",
+            {"search", "search and play", "light on"},
+        )
+        self.assertEqual(cmd, "search and play")
+        self.assertEqual(args, "宇多田ヒカル")
+
+    def test_build_dataset_rows_uses_feedback_correction_for_unresolved(self) -> None:
+        rows = [
+            {
+                "resolver_request_id": "req-known",
+                "event_name": "resolver.decision",
+                "resolver_resolved_command": "search and play",
+                "resolver_resolved_args": "",
+                "feedback_label": "",
+                "feedback_correction": "",
+                "input_text": "known sample",
+            },
+            {
+                "resolver_request_id": "req-unresolved",
+                "event_name": "resolver.decision",
+                "resolver_resolved_command": "",
+                "resolver_resolved_args": "",
+                "feedback_label": "",
+                "feedback_correction": "",
+                "input_text": "ヒッキー再生して",
+            },
+            {
+                "resolver_request_id": "req-unresolved",
+                "event_name": "resolver.feedback",
+                "resolver_resolved_command": "",
+                "resolver_resolved_args": "",
+                "feedback_label": "incorrect",
+                "feedback_correction": "search and play 宇多田ヒカル",
+                "input_text": "",
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "resolver-events.csv"
+            with csv_path.open("w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(rows)
+
+            dataset = build_dataset_rows(csv_path)
+
+        by_request = {row["request_id"]: row for row in dataset}
+        unresolved = by_request["req-unresolved"]
+        self.assertEqual(unresolved["expected_command"], "search and play")
+        self.assertEqual(unresolved["expected_args"], "宇多田ヒカル")
+        self.assertEqual(unresolved["feedback_label"], "incorrect")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Slack feedback UI for unresolved resolver responses so users can submit intended commands.
- Extend resolver feedback telemetry to include `resolver.path_hint`.
- Improve DSPy dataset generation to parse correction text with longest-known-command matching.

## Changes
- `server/slack/feedback.go`
  - Show unresolved-specific feedback blocks when `resolved_command` is empty.
  - Add `PathHint` to feedback action payload and propagate it through feedback recording.
- `internal/resolver/events.go`
  - Add `ResolverPathHint` to `FeedbackRecord` and emit `resolver.path_hint` on `resolver.feedback` events.
- `tools/dspy/prepare_dataset.py`
  - Add `split_correction_target` to recover `expected_command/expected_args` from correction text using known command names.
- Tests
  - `server/slack/feedback_test.go`
  - `internal/resolver/events_test.go`
  - `tools/dspy/prepare_dataset_test.py`

## Validation
- `gofmt -w server/slack/feedback.go server/slack/feedback_test.go internal/resolver/events.go internal/resolver/events_test.go`
- `golangci-lint run`
- `go test ./...`
- Python tests could not be executed in this environment because `python`/`py` command is unavailable.

## Related Issue
- Closes #162
