### PR TITLE
[Phase 1] SearchAndPlay normalize query and support aliases

### DIFF
--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -6,7 +6,11 @@
   },
   "owntone": {
     "url": "",
-    "timeout": 10
+    "timeout": 10,
+    "search_aliases": {
+      "ひげだん": "official髭男dism",
+      "mga": "mrs green apple"
+    }
   },
   "yamaha": {
     "url": "",

--- a/subcommand/action/owntone/client.go
+++ b/subcommand/action/owntone/client.go
@@ -27,8 +27,9 @@ type Client struct {
 
 // Config is the configuration for the Owntone client.
 type Config struct {
-	URL     string `json:"url"`
-	Timeout int    `json:"timeout"`
+	URL           string            `json:"url"`
+	Timeout       int               `json:"timeout"`
+	SearchAliases map[string]string `json:"search_aliases"`
 }
 
 // Validate validates the Owntone configuration.

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/johtani/smarthome/subcommand/action"
+	"golang.org/x/text/unicode/norm"
 )
 
 // SearchAndPlayAction represents an action to search for music and play it on Owntone.
@@ -31,7 +33,13 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	defer span.End()
 	msg := []string{"Search Results..."}
 	searchQuery := Parse(query)
-	result, err := a.c.Search(ctx, strings.Join(searchQuery.Terms, " "), searchQuery.TypeArray(), searchQuery.Limit)
+	originalKeyword := strings.Join(searchQuery.Terms, " ")
+	searchKeyword := normalizeSearchKeyword(originalKeyword, a.c.config.SearchAliases)
+	if strings.TrimSpace(searchKeyword) == "" {
+		searchKeyword = originalKeyword
+	}
+
+	result, err := a.c.Search(ctx, searchKeyword, searchQuery.TypeArray(), searchQuery.Limit)
 	if err != nil {
 		return "Something wrong...", fmt.Errorf("error in SearchAndDisplayAction\n %v", err)
 	}
@@ -71,7 +79,7 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	}
 
 	if len(result.Genres.Items) > 0 {
-		err = a.c.AddItem2QueueAndPlay(ctx, "", fmt.Sprintf("genre is \"%s\"", strings.Join(searchQuery.Terms, " ")))
+		err = a.c.AddItem2QueueAndPlay(ctx, "", fmt.Sprintf("genre is \"%s\"", searchKeyword))
 		if err != nil {
 			return "", fmt.Errorf("error calling AddItem2QueueAndPlay with expression\n %v", err)
 		}
@@ -198,4 +206,67 @@ func Parse(target string) *SearchQuery {
 		}
 	}
 	return &SearchQuery{Terms: queries, Limit: limit, Offset: offset, Types: types}
+}
+
+func normalizeSearchKeyword(keyword string, aliases map[string]string) string {
+	normalized := normalizeText(keyword)
+	if normalized == "" {
+		return ""
+	}
+	return applySearchAliases(normalized, aliases)
+}
+
+func applySearchAliases(keyword string, aliases map[string]string) string {
+	if len(aliases) == 0 {
+		return keyword
+	}
+
+	normalizedAliases := make(map[string]string, len(aliases))
+	for from, to := range aliases {
+		normalizedFrom := normalizeText(from)
+		normalizedTo := normalizeText(to)
+		if normalizedFrom == "" || normalizedTo == "" {
+			continue
+		}
+		normalizedAliases[normalizedFrom] = normalizedTo
+	}
+
+	if replaced, ok := normalizedAliases[keyword]; ok {
+		return replaced
+	}
+
+	terms := strings.Fields(keyword)
+	for i, term := range terms {
+		if replaced, ok := normalizedAliases[term]; ok {
+			terms[i] = replaced
+		}
+	}
+	return strings.Join(terms, " ")
+}
+
+func normalizeText(s string) string {
+	normalized := norm.NFKC.String(s)
+	var b strings.Builder
+	b.Grow(len(normalized))
+
+	for _, r := range normalized {
+		r = katakanaToHiragana(r)
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+		case unicode.IsSpace(r):
+			b.WriteByte(' ')
+		default:
+			// Treat punctuation/symbols as separators.
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func katakanaToHiragana(r rune) rune {
+	if r >= 'ァ' && r <= 'ヶ' {
+		return r - 0x60
+	}
+	return r
 }

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -2,8 +2,10 @@ package owntone
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -97,5 +99,122 @@ func TestSearchAndPlayAction_Run(t *testing.T) {
 
 	if !strings.Contains(got, "And play these items") {
 		t.Errorf("Run() result does not contain expected success message, got: %s", got)
+	}
+}
+
+func TestNormalizeText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "NFKC and lowercase", in: "ＴＥＳＴ　１２３", want: "test 123"},
+		{name: "Symbol collapse", in: "A・B!!! C", want: "a b c"},
+		{name: "Kana normalize", in: "ヒカル ひかる", want: "ひかる ひかる"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeText(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSearchKeyword(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyword string
+		aliases map[string]string
+		want    string
+	}{
+		{
+			name:    "alias with normalization",
+			keyword: "MGA",
+			aliases: map[string]string{"ｍｇａ": "Mrs. GREEN APPLE"},
+			want:    "mrs green apple",
+		},
+		{
+			name:    "term alias",
+			keyword: "宇多田 ヒッキー",
+			aliases: map[string]string{"ヒッキー": "宇多田ヒカル"},
+			want:    "宇多田 宇多田ひかる",
+		},
+		{
+			name:    "empty after normalization",
+			keyword: "!!!",
+			aliases: map[string]string{"x": "y"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeSearchKeyword(tt.keyword, tt.aliases)
+			if got != tt.want {
+				t.Fatalf("normalizeSearchKeyword() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchAndPlayAction_Run_UsesNormalizedQueryAndFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		aliases        map[string]string
+		wantSearchText string
+	}{
+		{
+			name:           "normalized alias query",
+			query:          "ＭＧＡ!!!",
+			aliases:        map[string]string{"mga": "Mrs GREEN APPLE"},
+			wantSearchText: "mrs green apple",
+		},
+		{
+			name:           "fallback to original terms when normalized empty",
+			query:          "!!! type:artist",
+			aliases:        nil,
+			wantSearchText: "!!!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedQuery string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
+				receivedQuery = r.URL.Query().Get("query")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(searchSampleJSONResponse()))
+			})
+			mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+			mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, "")
+			})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			client := NewClient(Config{URL: server.URL, SearchAliases: tt.aliases})
+			action := NewSearchAndPlayAction(client)
+
+			_, err := action.Run(context.Background(), tt.query)
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			got, err := url.QueryUnescape(receivedQuery)
+			if err != nil {
+				t.Fatalf("QueryUnescape() error = %v", err)
+			}
+			if got != tt.wantSearchText {
+				t.Fatalf("search query = %q, want %q", got, tt.wantSearchText)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- implement Phase 1 improvements for `search and play` with low-risk query preprocessing
- normalize search keyword before Owntone search (`NFKC`, lowercase, punctuation normalization, katakana->hiragana)
- support local alias dictionary via `owntone.search_aliases`
- keep existing `Parse -> Client.Search` flow and add fallback to original keyword when normalized result is empty

## Changes
- `subcommand/action/owntone/search.go`
  - apply normalized/aliased keyword in `SearchAndPlayAction.Run`
  - add normalization and alias helper functions
- `subcommand/action/owntone/client.go`
  - add `SearchAliases map[string]string` to Owntone config
- `subcommand/action/owntone/search_test.go`
  - add tests for normalization rules, alias application, and fallback behavior
- `config/config.json.sample`
  - add `search_aliases` example

## Verification
- `gofmt -w subcommand/action/owntone/search.go subcommand/action/owntone/search_test.go subcommand/action/owntone/client.go`
- `golangci-lint run` (pass)
- `go test ./...` (pass)

## Related
- Refs #165
