### PR TITLE
[Phase 1.5] SearchAndPlayをexpression検索へ切り替え

### DIFF
--- a/subcommand/action/owntone/client.go
+++ b/subcommand/action/owntone/client.go
@@ -282,6 +282,17 @@ type SearchResult struct {
 func (c Client) Search(ctx context.Context, keyword string, resultType []SearchType, limit int) (*SearchResult, error) {
 	params := map[string]string{}
 	params["query"] = keyword
+	return c.search(ctx, params, resultType, limit)
+}
+
+// SearchByExpression performs a search on the Owntone server using expression.
+func (c Client) SearchByExpression(ctx context.Context, expression string, resultType []SearchType, limit int) (*SearchResult, error) {
+	params := map[string]string{}
+	params["expression"] = expression
+	return c.search(ctx, params, resultType, limit)
+}
+
+func (c Client) search(ctx context.Context, params map[string]string, resultType []SearchType, limit int) (*SearchResult, error) {
 	l := limit
 	if limit <= 0 {
 		l = 5

--- a/subcommand/action/owntone/client_test.go
+++ b/subcommand/action/owntone/client_test.go
@@ -518,6 +518,7 @@ func TestClient_Search(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
+		params  map[string][]string
 		want    *SearchResult
 		wantErr bool
 	}{
@@ -525,6 +526,7 @@ func TestClient_Search(t *testing.T) {
 			name:   "OK",
 			fields: fields{statusCode: http.StatusOK, method: http.MethodGet, path: path, response: searchSampleJSONResponse()},
 			args:   args{keyword: "keyword", resultType: []SearchType{track}},
+			params: map[string][]string{"query": {"keyword"}, "type": {"track"}, "limit": {"5"}},
 			want: &SearchResult{
 				Tracks: Items{Items: []SearchItem{
 					{
@@ -577,11 +579,11 @@ func TestClient_Search(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{"NG", fields{statusCode: http.StatusInternalServerError, method: http.MethodGet, path: path, response: searchSampleJSONResponse()}, args{keyword: "keyword", resultType: []SearchType{track}}, nil, true},
+		{"NG", fields{statusCode: http.StatusInternalServerError, method: http.MethodGet, path: path, response: searchSampleJSONResponse()}, args{keyword: "keyword", resultType: []SearchType{track}}, map[string][]string{"query": {"keyword"}, "type": {"track"}, "limit": {"5"}}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := createMockServerWithResponse(tt.fields.statusCode, tt.fields.method, tt.fields.path, nil, tt.fields.response)
+			server := createMockServerWithResponse(tt.fields.statusCode, tt.fields.method, tt.fields.path, tt.params, tt.fields.response)
 			defer server.Close()
 			config := Config{URL: server.URL}
 			c := NewClient(config)
@@ -593,6 +595,57 @@ func TestClient_Search(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Search() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_SearchByExpression(t *testing.T) {
+	type fields struct {
+		statusCode int
+		method     string
+		path       string
+		response   string
+	}
+	type args struct {
+		expression string
+		resultType []SearchType
+		limit      int
+	}
+	path := "/api/search"
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		params  map[string][]string
+		wantErr bool
+	}{
+		{
+			name:    "OK",
+			fields:  fields{statusCode: http.StatusOK, method: http.MethodGet, path: path, response: searchSampleJSONResponse()},
+			args:    args{expression: "title includes \"keyword\"", resultType: []SearchType{track}, limit: 2},
+			params:  map[string][]string{"expression": {"title includes \"keyword\""}, "type": {"track"}, "limit": {"2"}},
+			wantErr: false,
+		},
+		{
+			name:    "NG",
+			fields:  fields{statusCode: http.StatusInternalServerError, method: http.MethodGet, path: path, response: searchSampleJSONResponse()},
+			args:    args{expression: "title includes \"keyword\"", resultType: []SearchType{track}, limit: 2},
+			params:  map[string][]string{"expression": {"title includes \"keyword\""}, "type": {"track"}, "limit": {"2"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := createMockServerWithResponse(tt.fields.statusCode, tt.fields.method, tt.fields.path, tt.params, tt.fields.response)
+			defer server.Close()
+			config := Config{URL: server.URL}
+			c := NewClient(config)
+
+			_, err := c.SearchByExpression(context.Background(), tt.args.expression, tt.args.resultType, tt.args.limit)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchByExpression() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -3,6 +3,7 @@ package owntone
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -38,8 +39,9 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	if strings.TrimSpace(searchKeyword) == "" {
 		searchKeyword = originalKeyword
 	}
+	keywords := buildSearchKeywords(originalKeyword, searchKeyword)
 
-	result, err := a.c.Search(ctx, searchKeyword, searchQuery.TypeArray(), searchQuery.Limit)
+	result, err := a.searchWithFallback(ctx, keywords, searchKeyword, searchQuery.TypeArray(), searchQuery.Limit)
 	if err != nil {
 		return "Something wrong...", fmt.Errorf("error in SearchAndDisplayAction\n %v", err)
 	}
@@ -91,6 +93,19 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 		msg = append(msg, "And no play items...")
 	}
 	return strings.Join(msg, "\n"), nil
+}
+
+func (a SearchAndPlayAction) searchWithFallback(ctx context.Context, keywords []string, fallbackKeyword string, types []SearchType, limit int) (*SearchResult, error) {
+	expression := buildSearchExpression(keywords, types)
+	if expression == "" {
+		return a.c.Search(ctx, fallbackKeyword, types, limit)
+	}
+
+	result, err := a.c.SearchByExpression(ctx, expression, types, limit)
+	if err != nil || totalSearchResultCount(result) == 0 {
+		return a.c.Search(ctx, fallbackKeyword, types, limit)
+	}
+	return result, nil
 }
 
 // NewSearchAndPlayAction creates a new SearchAndPlayAction.
@@ -206,6 +221,83 @@ func Parse(target string) *SearchQuery {
 		}
 	}
 	return &SearchQuery{Terms: queries, Limit: limit, Offset: offset, Types: types}
+}
+
+func buildSearchKeywords(originalKeyword string, normalizedKeyword string) []string {
+	var keywords []string
+	for _, keyword := range []string{originalKeyword, normalizedKeyword} {
+		trimmed := strings.TrimSpace(keyword)
+		if trimmed == "" || slices.Contains(keywords, trimmed) {
+			continue
+		}
+		keywords = append(keywords, trimmed)
+	}
+	return keywords
+}
+
+func buildSearchExpression(keywords []string, types []SearchType) string {
+	fields := expressionFields(types)
+	if len(fields) == 0 || len(keywords) == 0 {
+		return ""
+	}
+
+	keywordClauses := make([]string, 0, len(keywords))
+	for _, keyword := range keywords {
+		fieldClauses := make([]string, 0, len(fields))
+		escaped := escapeExpressionValue(keyword)
+		for _, field := range fields {
+			fieldClauses = append(fieldClauses, fmt.Sprintf("%s includes \"%s\"", field, escaped))
+		}
+		keywordClauses = append(keywordClauses, fmt.Sprintf("(%s)", strings.Join(fieldClauses, " or ")))
+	}
+	return strings.Join(keywordClauses, " or ")
+}
+
+func expressionFields(types []SearchType) []string {
+	if len(types) == 0 {
+		types = []SearchType{artist, album, track, genre}
+	}
+
+	seen := map[string]struct{}{}
+	fields := []string{}
+	appendFields := func(candidates ...string) {
+		for _, candidate := range candidates {
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			fields = append(fields, candidate)
+		}
+	}
+
+	for _, searchType := range types {
+		switch searchType {
+		case artist:
+			appendFields("artist")
+		case album:
+			appendFields("album")
+		case track:
+			appendFields("title", "artist", "album")
+		case genre:
+			appendFields("genre")
+		}
+	}
+	return fields
+}
+
+func escapeExpressionValue(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"\"", "\\\"",
+	)
+	return replacer.Replace(value)
+}
+
+func totalSearchResultCount(result *SearchResult) int {
+	if result == nil {
+		return 0
+	}
+	return result.Artists.Total + result.Albums.Total + result.Tracks.Total + result.Genres.Total + result.Playlists.Total
 }
 
 func normalizeSearchKeyword(keyword string, aliases map[string]string) string {

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -162,32 +161,71 @@ func TestNormalizeSearchKeyword(t *testing.T) {
 
 func TestSearchAndPlayAction_Run_UsesNormalizedQueryAndFallback(t *testing.T) {
 	tests := []struct {
-		name           string
-		query          string
-		aliases        map[string]string
-		wantSearchText string
+		name                string
+		query               string
+		aliases             map[string]string
+		expressionStatus    int
+		expressionResponse  string
+		queryStatus         int
+		wantExpressionParts []string
+		wantQueryText       string
 	}{
 		{
-			name:           "normalized alias query",
-			query:          "ＭＧＡ!!!",
-			aliases:        map[string]string{"mga": "Mrs GREEN APPLE"},
-			wantSearchText: "mrs green apple",
+			name:               "expression search uses original and normalized keywords",
+			query:              "ＭＧＡ!!!",
+			aliases:            map[string]string{"mga": "Mrs GREEN APPLE"},
+			expressionStatus:   http.StatusOK,
+			expressionResponse: searchSampleJSONResponse(),
+			queryStatus:        http.StatusOK,
+			wantExpressionParts: []string{
+				"title includes \"ＭＧＡ!!!\"",
+				"title includes \"mrs green apple\"",
+			},
+			wantQueryText: "",
 		},
 		{
-			name:           "fallback to original terms when normalized empty",
-			query:          "!!! type:artist",
-			aliases:        nil,
-			wantSearchText: "!!!",
+			name:               "fallback to query when expression search returns error",
+			query:              "ＭＧＡ!!! type:track",
+			aliases:            map[string]string{"mga": "Mrs GREEN APPLE"},
+			expressionStatus:   http.StatusBadRequest,
+			expressionResponse: `{"message":"invalid expression"}`,
+			queryStatus:        http.StatusOK,
+			wantExpressionParts: []string{
+				"title includes \"ＭＧＡ!!!\"",
+				"title includes \"mrs green apple\"",
+			},
+			wantQueryText: "mrs green apple",
+		},
+		{
+			name:               "fallback to query when expression search has no hit",
+			query:              "!!! type:artist",
+			aliases:            nil,
+			expressionStatus:   http.StatusOK,
+			expressionResponse: emptySearchJSONResponse(),
+			queryStatus:        http.StatusOK,
+			wantExpressionParts: []string{
+				"artist includes \"!!!\"",
+			},
+			wantQueryText: "!!!",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var receivedQuery string
+			var receivedExpressions []string
+			var receivedQueries []string
 			mux := http.NewServeMux()
 			mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
-				receivedQuery = r.URL.Query().Get("query")
-				w.WriteHeader(http.StatusOK)
+				receivedExpression := r.URL.Query().Get("expression")
+				receivedQuery := r.URL.Query().Get("query")
+				receivedExpressions = append(receivedExpressions, receivedExpression)
+				receivedQueries = append(receivedQueries, receivedQuery)
+				if receivedExpression != "" {
+					w.WriteHeader(tt.expressionStatus)
+					_, _ = w.Write([]byte(tt.expressionResponse))
+					return
+				}
+				w.WriteHeader(tt.queryStatus)
 				_, _ = w.Write([]byte(searchSampleJSONResponse()))
 			})
 			mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
@@ -208,13 +246,75 @@ func TestSearchAndPlayAction_Run_UsesNormalizedQueryAndFallback(t *testing.T) {
 				t.Fatalf("Run() error = %v", err)
 			}
 
-			got, err := url.QueryUnescape(receivedQuery)
-			if err != nil {
-				t.Fatalf("QueryUnescape() error = %v", err)
+			expression := ""
+			for _, v := range receivedExpressions {
+				if v != "" {
+					expression = v
+					break
+				}
 			}
-			if got != tt.wantSearchText {
-				t.Fatalf("search query = %q, want %q", got, tt.wantSearchText)
+			for _, part := range tt.wantExpressionParts {
+				if !strings.Contains(expression, part) {
+					t.Fatalf("expression = %q, want to contain %q", expression, part)
+				}
+			}
+
+			query := ""
+			for _, v := range receivedQueries {
+				if v != "" {
+					query = v
+				}
+			}
+			if query != tt.wantQueryText {
+				t.Fatalf("search query = %q, want %q", query, tt.wantQueryText)
 			}
 		})
 	}
+}
+
+func TestBuildSearchExpression(t *testing.T) {
+	tests := []struct {
+		name     string
+		keywords []string
+		types    []SearchType
+		want     string
+	}{
+		{
+			name:     "track type expression",
+			keywords: []string{"Utada", "宇多田ひかる"},
+			types:    []SearchType{track},
+			want:     "(title includes \"Utada\" or artist includes \"Utada\" or album includes \"Utada\") or (title includes \"宇多田ひかる\" or artist includes \"宇多田ひかる\" or album includes \"宇多田ひかる\")",
+		},
+		{
+			name:     "escape quote and slash",
+			keywords: []string{`A"B\C`},
+			types:    []SearchType{artist},
+			want:     `(artist includes "A\"B\\C")`,
+		},
+		{
+			name:     "empty keywords",
+			keywords: nil,
+			types:    []SearchType{artist},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSearchExpression(tt.keywords, tt.types)
+			if got != tt.want {
+				t.Fatalf("buildSearchExpression() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func emptySearchJSONResponse() string {
+	return `{
+  "tracks": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "artists": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "albums": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "genres": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "playlists": {"items": [], "total": 0, "offset": 0, "limit": 5}
+}`
 }


### PR DESCRIPTION
## Summary
SearchAndPlay を Owntone `expression` 検索ベースに切り替え、正規化語と元語の OR 検索を導入しました。`expression` でエラーまたは 0 件の場合は既存の `query` 検索へフォールバックします。

## Changes
- `SearchAndPlayAction` の検索経路を `expression` 優先 + `query` フォールバックに変更
- 元キーワード/正規化キーワードを重複除去して OR 条件の expression を生成
- type 指定に応じて expression の対象フィールドを切り替え
- expression 値のエスケープ（`"`, `\\`）を実装
- Owntone client に `SearchByExpression()` を追加し、検索処理を共通化
- expression パラメータ送信、フォールバック挙動、expression ビルドのテストを追加

## Validation
- `gofmt -w subcommand/action/owntone/client.go subcommand/action/owntone/search.go subcommand/action/owntone/client_test.go subcommand/action/owntone/search_test.go`
- `go test ./subcommand/action/owntone`
- `go test ./...`
- `golangci-lint run`

## Related Issue
- Closes #168
