### PR TITLE
[Phase 2] search and play に Music Intent 解決を追加

### DIFF
--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -10,7 +10,10 @@
     "search_aliases": {
       "ひげだん": "official髭男dism",
       "mga": "mrs green apple"
-    }
+    },
+    "music_intent_endpoint": "",
+    "music_intent_timeout_seconds": 5,
+    "music_intent_confidence_threshold": 0.75
   },
   "yamaha": {
     "url": "",

--- a/subcommand/action/owntone/client.go
+++ b/subcommand/action/owntone/client.go
@@ -27,12 +27,13 @@ type Client struct {
 
 // Config is the configuration for the Owntone client.
 type Config struct {
-	URL                            string            `json:"url"`
-	Timeout                        int               `json:"timeout"`
-	SearchAliases                  map[string]string `json:"search_aliases"`
-	MusicIntentEndpoint            string            `json:"music_intent_endpoint"`
-	MusicIntentTimeoutSeconds      int               `json:"music_intent_timeout_seconds"`
-	MusicIntentConfidenceThreshold float64           `json:"music_intent_confidence_threshold"`
+	URL                               string            `json:"url"`
+	Timeout                           int               `json:"timeout"`
+	SearchAliases                     map[string]string `json:"search_aliases"`
+	MusicIntentEndpoint               string            `json:"music_intent_endpoint"`
+	MusicIntentTimeoutSeconds         int               `json:"music_intent_timeout_seconds"`
+	MusicIntentConfidenceThreshold    float64           `json:"music_intent_confidence_threshold"`
+	MusicIntentConfidenceThresholdSet bool              `json:"-"`
 }
 
 // Validate validates the Owntone configuration.

--- a/subcommand/action/owntone/client.go
+++ b/subcommand/action/owntone/client.go
@@ -27,9 +27,12 @@ type Client struct {
 
 // Config is the configuration for the Owntone client.
 type Config struct {
-	URL           string            `json:"url"`
-	Timeout       int               `json:"timeout"`
-	SearchAliases map[string]string `json:"search_aliases"`
+	URL                            string            `json:"url"`
+	Timeout                        int               `json:"timeout"`
+	SearchAliases                  map[string]string `json:"search_aliases"`
+	MusicIntentEndpoint            string            `json:"music_intent_endpoint"`
+	MusicIntentTimeoutSeconds      int               `json:"music_intent_timeout_seconds"`
+	MusicIntentConfidenceThreshold float64           `json:"music_intent_confidence_threshold"`
 }
 
 // Validate validates the Owntone configuration.

--- a/subcommand/action/owntone/music_intent.go
+++ b/subcommand/action/owntone/music_intent.go
@@ -1,0 +1,45 @@
+package owntone
+
+import "strings"
+
+// MusicIntent is a structured representation of music search intent.
+type MusicIntent struct {
+	ArtistCandidates []string `json:"artist_candidates"`
+	TrackCandidates  []string `json:"track_candidates"`
+	GenreCandidates  []string `json:"genre_candidates"`
+	MustTerms        []string `json:"must_terms"`
+	Confidence       float64  `json:"confidence"`
+	Ambiguous        bool     `json:"ambiguous,omitempty"`
+	Reason           string   `json:"reason"`
+	Model            string   `json:"model,omitempty"`
+}
+
+// IsEmpty returns true when the intent does not contain any actionable tokens.
+func (m MusicIntent) IsEmpty() bool {
+	return len(m.StrictKeywords()) == 0
+}
+
+// StrictKeywords returns de-duplicated keywords used for strict AND search.
+func (m MusicIntent) StrictKeywords() []string {
+	seen := map[string]struct{}{}
+	keywords := make([]string, 0, len(m.ArtistCandidates)+len(m.TrackCandidates)+len(m.GenreCandidates)+len(m.MustTerms))
+	appendUnique := func(values []string) {
+		for _, value := range values {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			keywords = append(keywords, trimmed)
+		}
+	}
+
+	appendUnique(m.ArtistCandidates)
+	appendUnique(m.TrackCandidates)
+	appendUnique(m.GenreCandidates)
+	appendUnique(m.MustTerms)
+	return keywords
+}

--- a/subcommand/action/owntone/music_intent_resolver.go
+++ b/subcommand/action/owntone/music_intent_resolver.go
@@ -1,0 +1,97 @@
+package owntone
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// MusicIntentResolver resolves free text into a structured music intent.
+type MusicIntentResolver interface {
+	Path() string
+	Resolve(ctx context.Context, text string) (MusicIntent, error)
+}
+
+type httpMusicIntentResolver struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NewHTTPMusicIntentResolver creates an HTTP-based music intent resolver.
+func NewHTTPMusicIntentResolver(endpoint string, timeout time.Duration) MusicIntentResolver {
+	trimmedEndpoint := strings.TrimSpace(endpoint)
+	if trimmedEndpoint == "" {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return httpMusicIntentResolver{
+		endpoint: trimmedEndpoint,
+		httpClient: &http.Client{
+			Timeout:   timeout,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
+}
+
+func (r httpMusicIntentResolver) Path() string {
+	return "music_intent_http"
+}
+
+func (r httpMusicIntentResolver) Resolve(ctx context.Context, text string) (MusicIntent, error) {
+	payload, err := json.Marshal(map[string]string{"text": strings.TrimSpace(text)})
+	if err != nil {
+		return MusicIntent{}, fmt.Errorf("failed to marshal music intent payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return MusicIntent{}, fmt.Errorf("failed to build music intent request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return MusicIntent{}, fmt.Errorf("failed to send music intent request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return MusicIntent{}, fmt.Errorf("failed to read music intent response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return MusicIntent{}, fmt.Errorf("unexpected music intent status code: %d", resp.StatusCode)
+	}
+
+	var wrapped struct {
+		MusicIntent MusicIntent `json:"music_intent"`
+		Model       string      `json:"model"`
+		Reason      string      `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &wrapped); err == nil && !wrapped.MusicIntent.IsEmpty() {
+		if strings.TrimSpace(wrapped.MusicIntent.Model) == "" {
+			wrapped.MusicIntent.Model = strings.TrimSpace(wrapped.Model)
+		}
+		if strings.TrimSpace(wrapped.MusicIntent.Reason) == "" {
+			wrapped.MusicIntent.Reason = strings.TrimSpace(wrapped.Reason)
+		}
+		return wrapped.MusicIntent, nil
+	}
+
+	var intent MusicIntent
+	if err := json.Unmarshal(body, &intent); err != nil {
+		return MusicIntent{}, fmt.Errorf("failed to decode music intent response: %w", err)
+	}
+	return intent, nil
+}

--- a/subcommand/action/owntone/music_intent_resolver_test.go
+++ b/subcommand/action/owntone/music_intent_resolver_test.go
@@ -1,0 +1,62 @@
+package owntone
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPMusicIntentResolver_Resolve_DirectIntent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"artist_candidates":["宇多田ヒカル"],"confidence":0.9}`))
+	}))
+	defer server.Close()
+
+	r := NewHTTPMusicIntentResolver(server.URL, 2*time.Second)
+	intent, err := r.Resolve(context.Background(), "宇多田ヒカルを再生")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(intent.ArtistCandidates) != 1 || intent.ArtistCandidates[0] != "宇多田ヒカル" {
+		t.Fatalf("unexpected intent: %+v", intent)
+	}
+}
+
+func TestHTTPMusicIntentResolver_Resolve_WrappedIntent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"music_intent":{"track_candidates":["First Love"],"confidence":0.8},"model":"gpt-test","reason":"wrapped"}`))
+	}))
+	defer server.Close()
+
+	r := NewHTTPMusicIntentResolver(server.URL, 2*time.Second)
+	intent, err := r.Resolve(context.Background(), "First Love")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(intent.TrackCandidates) != 1 || intent.TrackCandidates[0] != "First Love" {
+		t.Fatalf("unexpected intent: %+v", intent)
+	}
+	if intent.Model != "gpt-test" {
+		t.Fatalf("model = %q, want %q", intent.Model, "gpt-test")
+	}
+	if intent.Reason != "wrapped" {
+		t.Fatalf("reason = %q, want %q", intent.Reason, "wrapped")
+	}
+}
+
+func TestHTTPMusicIntentResolver_Resolve_Non200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	r := NewHTTPMusicIntentResolver(server.URL, 2*time.Second)
+	_, err := r.Resolve(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -2,20 +2,47 @@ package owntone
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
 	"unicode"
 
+	"github.com/johtani/smarthome/internal/resolver"
 	"github.com/johtani/smarthome/subcommand/action"
 	"golang.org/x/text/unicode/norm"
 )
 
+const defaultMusicIntentConfidenceThreshold = 0.75
+
 // SearchAndPlayAction represents an action to search for music and play it on Owntone.
 type SearchAndPlayAction struct {
-	name string
-	c    *Client
+	name                           string
+	c                              *Client
+	musicIntentResolver            MusicIntentResolver
+	musicIntentConfidenceThreshold float64
+}
+
+// SearchAndPlayActionOption customizes SearchAndPlayAction behavior.
+type SearchAndPlayActionOption func(*SearchAndPlayAction)
+
+// WithMusicIntentResolver sets the music intent resolver.
+func WithMusicIntentResolver(r MusicIntentResolver) SearchAndPlayActionOption {
+	return func(a *SearchAndPlayAction) {
+		a.musicIntentResolver = r
+	}
+}
+
+// WithMusicIntentConfidenceThreshold sets the confidence threshold for auto play.
+func WithMusicIntentConfidenceThreshold(threshold float64) SearchAndPlayActionOption {
+	return func(a *SearchAndPlayAction) {
+		if threshold >= 0 {
+			a.musicIntentConfidenceThreshold = threshold
+		}
+	}
 }
 
 func appendMessage(items Items, label string, msg []string, uris []string, loopFunc func(item SearchItem, msg []string) ([]string, []string)) ([]string, []string) {
@@ -32,7 +59,7 @@ func appendMessage(items Items, label string, msg []string, uris []string, loopF
 func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, error) {
 	ctx, span := action.StartRunSpan(ctx, "owntone", "SearchAndPlayAction.Run", query)
 	defer span.End()
-	msg := []string{"Search Results..."}
+
 	searchQuery := Parse(query)
 	originalKeyword := strings.Join(searchQuery.Terms, " ")
 	searchKeyword := normalizeSearchKeyword(originalKeyword, a.c.config.SearchAliases)
@@ -40,11 +67,146 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 		searchKeyword = originalKeyword
 	}
 	keywords := buildSearchKeywords(originalKeyword, searchKeyword)
+	types := searchQuery.TypeArray()
 
-	result, err := a.searchWithFallback(ctx, keywords, searchKeyword, searchQuery.TypeArray(), searchQuery.Limit)
+	if intent, path, ok := a.resolveMusicIntent(ctx, originalKeyword); ok {
+		strictKeywords := intent.StrictKeywords()
+		if len(strictKeywords) > 0 {
+			strictExpression := buildSearchExpressionAND(strictKeywords, types)
+			if strictExpression != "" {
+				strictResult, err := a.c.SearchByExpression(ctx, strictExpression, types, searchQuery.Limit)
+				if err == nil && totalSearchResultCount(strictResult) > 0 {
+					resolver.RecordDecision(ctx, resolver.DecisionRecord{
+						InputTextHash:   hashInputText(originalKeyword),
+						ResolverPath:    "music_intent_strict",
+						ResolvedCommand: "search and play",
+						ResolvedArgs:    query,
+						LLMModel:        intent.Model,
+					})
+					if a.shouldSuggestCandidates(intent, strictResult) {
+						resolver.RecordExecution(ctx, resolver.ExecutionRecord{
+							ExecutionStatus:  "candidate_only",
+							ResolvedCommand:  "search and play",
+							ResolvedArgs:     query,
+							ResolverPathHint: path,
+						})
+						return buildCandidateMessage(strictResult, intent), nil
+					}
+					resolver.RecordExecution(ctx, resolver.ExecutionRecord{
+						ExecutionStatus:  "success_music_intent_strict",
+						ResolvedCommand:  "search and play",
+						ResolvedArgs:     query,
+						ResolverPathHint: path,
+					})
+					return a.playAndBuildMessage(ctx, strictResult, genreKeywordFromIntent(intent, a.c.config.SearchAliases, searchKeyword))
+				}
+			}
+		}
+	}
+
+	result, fallbackPath, err := a.searchWithFallback(ctx, keywords, searchKeyword, types, searchQuery.Limit)
 	if err != nil {
+		resolver.RecordExecution(ctx, resolver.ExecutionRecord{
+			ExecutionStatus:  "search_error",
+			ResolvedCommand:  "search and play",
+			ResolvedArgs:     query,
+			ResolverPathHint: fallbackPath,
+		})
 		return "Something wrong...", fmt.Errorf("error in SearchAndDisplayAction\n %v", err)
 	}
+
+	executionStatus := "success_alias"
+	if fallbackPath == "legacy_query" {
+		executionStatus = "fallback_legacy_success"
+	}
+	resolver.RecordExecution(ctx, resolver.ExecutionRecord{
+		ExecutionStatus:  executionStatus,
+		ResolvedCommand:  "search and play",
+		ResolvedArgs:     query,
+		ResolverPathHint: fallbackPath,
+	})
+	return a.playAndBuildMessage(ctx, result, searchKeyword)
+}
+
+func (a SearchAndPlayAction) resolveMusicIntent(ctx context.Context, keyword string) (MusicIntent, string, bool) {
+	if a.musicIntentResolver == nil {
+		return MusicIntent{}, "music_intent_disabled", false
+	}
+	if strings.TrimSpace(keyword) == "" {
+		return MusicIntent{}, a.musicIntentResolver.Path(), false
+	}
+
+	intent, err := a.musicIntentResolver.Resolve(ctx, keyword)
+	if err != nil {
+		slog.WarnContext(ctx, "music intent resolver failed", "path", a.musicIntentResolver.Path(), "error", err)
+		resolver.RecordDecision(ctx, resolver.DecisionRecord{
+			InputTextHash:   hashInputText(keyword),
+			ResolverPath:    "music_intent_error",
+			ResolvedCommand: "search and play",
+			ResolvedArgs:    keyword,
+		})
+		return MusicIntent{}, a.musicIntentResolver.Path(), false
+	}
+
+	if intent.IsEmpty() {
+		resolver.RecordDecision(ctx, resolver.DecisionRecord{
+			InputTextHash:   hashInputText(keyword),
+			ResolverPath:    "music_intent_empty",
+			ResolvedCommand: "search and play",
+			ResolvedArgs:    keyword,
+			LLMModel:        intent.Model,
+		})
+		return MusicIntent{}, a.musicIntentResolver.Path(), false
+	}
+
+	resolver.RecordDecision(ctx, resolver.DecisionRecord{
+		InputTextHash:   hashInputText(keyword),
+		ResolverPath:    a.musicIntentResolver.Path(),
+		ResolvedCommand: "search and play",
+		ResolvedArgs:    keyword,
+		LLMModel:        intent.Model,
+	})
+	return intent, a.musicIntentResolver.Path(), true
+}
+
+func (a SearchAndPlayAction) shouldSuggestCandidates(intent MusicIntent, result *SearchResult) bool {
+	if intent.Confidence > 0 && intent.Confidence < a.musicIntentConfidenceThreshold {
+		return true
+	}
+
+	// Tie/ambiguity should be explicit from resolver side to avoid over-triggering.
+	return intent.Ambiguous && result != nil && totalSearchResultCount(result) > 0
+}
+
+func buildCandidateMessage(result *SearchResult, intent MusicIntent) string {
+	msg := []string{"Search Results...", "Candidate results only (no autoplay)."}
+	if intent.Confidence > 0 {
+		msg = append(msg, fmt.Sprintf("Reason: low confidence (%.2f)", intent.Confidence))
+	}
+	if strings.TrimSpace(intent.Reason) != "" {
+		msg = append(msg, "Resolver note: "+intent.Reason)
+	}
+	msg, _ = appendMessage(result.Artists, "Artists", msg, nil, func(item SearchItem, msg []string) ([]string, []string) {
+		msg = append(msg, fmt.Sprintf(" %v", item.Name))
+		return msg, nil
+	})
+	msg, _ = appendMessage(result.Albums, "Albums", msg, nil, func(item SearchItem, msg []string) ([]string, []string) {
+		msg = append(msg, fmt.Sprintf(" %v / %v", item.Name, item.Artist))
+		return msg, nil
+	})
+	msg, _ = appendMessage(result.Tracks, "Tracks", msg, nil, func(item SearchItem, msg []string) ([]string, []string) {
+		msg = append(msg, fmt.Sprintf(" %v / %v ", item.Title, item.Artist))
+		return msg, nil
+	})
+	msg, _ = appendMessage(result.Genres, "Genres", msg, nil, func(item SearchItem, msg []string) ([]string, []string) {
+		msg = append(msg, fmt.Sprintf(" %v ", item.Name))
+		return msg, nil
+	})
+	return strings.Join(msg, "\n")
+}
+
+func (a SearchAndPlayAction) playAndBuildMessage(ctx context.Context, result *SearchResult, genreKeyword string) (string, error) {
+	msg := []string{"Search Results..."}
 	var uris []string
 	msg, uris = appendMessage(result.Artists, "Artists", msg, uris, func(item SearchItem, msg []string) ([]string, []string) {
 		msg = append(msg, fmt.Sprintf(" %v", item.Name))
@@ -74,14 +236,14 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	}
 
 	if len(uris) > 0 {
-		err = a.c.AddItem2QueueAndPlay(ctx, strings.Join(uris, ","), "")
+		err := a.c.AddItem2QueueAndPlay(ctx, strings.Join(uris, ","), "")
 		if err != nil {
 			return "", fmt.Errorf("error calling AddItem2QueueAndPlay\n %v", err)
 		}
 	}
 
 	if len(result.Genres.Items) > 0 {
-		err = a.c.AddItem2QueueAndPlay(ctx, "", fmt.Sprintf("genre is \"%s\"", searchKeyword))
+		err := a.c.AddItem2QueueAndPlay(ctx, "", fmt.Sprintf("genre is \"%s\"", genreKeyword))
 		if err != nil {
 			return "", fmt.Errorf("error calling AddItem2QueueAndPlay with expression\n %v", err)
 		}
@@ -95,25 +257,32 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	return strings.Join(msg, "\n"), nil
 }
 
-func (a SearchAndPlayAction) searchWithFallback(ctx context.Context, keywords []string, fallbackKeyword string, types []SearchType, limit int) (*SearchResult, error) {
+func (a SearchAndPlayAction) searchWithFallback(ctx context.Context, keywords []string, fallbackKeyword string, types []SearchType, limit int) (*SearchResult, string, error) {
 	expression := buildSearchExpression(keywords, types)
 	if expression == "" {
-		return a.c.Search(ctx, fallbackKeyword, types, limit)
+		result, err := a.c.Search(ctx, fallbackKeyword, types, limit)
+		return result, "legacy_query", err
 	}
 
 	result, err := a.c.SearchByExpression(ctx, expression, types, limit)
 	if err != nil || totalSearchResultCount(result) == 0 {
-		return a.c.Search(ctx, fallbackKeyword, types, limit)
+		fallback, fallbackErr := a.c.Search(ctx, fallbackKeyword, types, limit)
+		return fallback, "legacy_query", fallbackErr
 	}
-	return result, nil
+	return result, "alias_expression", nil
 }
 
 // NewSearchAndPlayAction creates a new SearchAndPlayAction.
-func NewSearchAndPlayAction(client *Client) SearchAndPlayAction {
-	return SearchAndPlayAction{
-		name: "Search and Play music on Owntone by keyword",
-		c:    client,
+func NewSearchAndPlayAction(client *Client, opts ...SearchAndPlayActionOption) SearchAndPlayAction {
+	a := SearchAndPlayAction{
+		name:                           "Search and Play music on Owntone by keyword",
+		c:                              client,
+		musicIntentConfidenceThreshold: defaultMusicIntentConfidenceThreshold,
 	}
+	for _, opt := range opts {
+		opt(&a)
+	}
+	return a
 }
 
 // SearchAndDisplayAction represents an action to search for music and display the results from Owntone.
@@ -253,6 +422,24 @@ func buildSearchExpression(keywords []string, types []SearchType) string {
 	return strings.Join(keywordClauses, " or ")
 }
 
+func buildSearchExpressionAND(keywords []string, types []SearchType) string {
+	fields := expressionFields(types)
+	if len(fields) == 0 || len(keywords) == 0 {
+		return ""
+	}
+
+	keywordClauses := make([]string, 0, len(keywords))
+	for _, keyword := range keywords {
+		fieldClauses := make([]string, 0, len(fields))
+		escaped := escapeExpressionValue(keyword)
+		for _, field := range fields {
+			fieldClauses = append(fieldClauses, fmt.Sprintf("%s includes \"%s\"", field, escaped))
+		}
+		keywordClauses = append(keywordClauses, fmt.Sprintf("(%s)", strings.Join(fieldClauses, " or ")))
+	}
+	return strings.Join(keywordClauses, " and ")
+}
+
 func expressionFields(types []SearchType) []string {
 	if len(types) == 0 {
 		types = []SearchType{artist, album, track, genre}
@@ -361,4 +548,19 @@ func katakanaToHiragana(r rune) rune {
 		return r - 0x60
 	}
 	return r
+}
+
+func hashInputText(text string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(text)))
+	return hex.EncodeToString(sum[:12])
+}
+
+func genreKeywordFromIntent(intent MusicIntent, aliases map[string]string, fallback string) string {
+	for _, candidate := range intent.GenreCandidates {
+		normalized := normalizeSearchKeyword(candidate, aliases)
+		if strings.TrimSpace(normalized) != "" {
+			return normalized
+		}
+	}
+	return fallback
 }

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -2,6 +2,7 @@ package owntone
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -306,6 +307,217 @@ func TestBuildSearchExpression(t *testing.T) {
 				t.Fatalf("buildSearchExpression() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildSearchExpressionAND(t *testing.T) {
+	got := buildSearchExpressionAND([]string{"Utada", "First Love"}, []SearchType{track})
+	want := "(title includes \"Utada\" or artist includes \"Utada\" or album includes \"Utada\") and (title includes \"First Love\" or artist includes \"First Love\" or album includes \"First Love\")"
+	if got != want {
+		t.Fatalf("buildSearchExpressionAND() = %q, want %q", got, want)
+	}
+}
+
+type fakeMusicIntentResolver struct {
+	intent MusicIntent
+	err    error
+}
+
+func (f fakeMusicIntentResolver) Path() string {
+	return "fake_music_intent"
+}
+
+func (f fakeMusicIntentResolver) Resolve(_ context.Context, _ string) (MusicIntent, error) {
+	if f.err != nil {
+		return MusicIntent{}, f.err
+	}
+	return f.intent, nil
+}
+
+func TestSearchAndPlayAction_Run_LowConfidenceShowsCandidatesWithoutPlaying(t *testing.T) {
+	var receivedExpression string
+	var clearQueueCalled bool
+	var addQueueCalled bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
+		receivedExpression = r.URL.Query().Get("expression")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, searchSampleJSONResponse())
+	})
+	mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+		clearQueueCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, _ *http.Request) {
+		addQueueCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := NewClient(Config{URL: server.URL})
+	action := NewSearchAndPlayAction(
+		client,
+		WithMusicIntentResolver(fakeMusicIntentResolver{
+			intent: MusicIntent{
+				ArtistCandidates: []string{"宇多田ヒカル"},
+				TrackCandidates:  []string{"First Love"},
+				Confidence:       0.40,
+			},
+		}),
+		WithMusicIntentConfidenceThreshold(0.75),
+	)
+
+	got, err := action.Run(context.Background(), "宇多田ヒカルのFirst Loveかけて")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(got, "Candidate results only (no autoplay).") {
+		t.Fatalf("Run() result = %q, want candidate-only message", got)
+	}
+	if !strings.Contains(receivedExpression, " and ") {
+		t.Fatalf("strict expression = %q, want AND expression", receivedExpression)
+	}
+	if clearQueueCalled || addQueueCalled {
+		t.Fatalf("expected no playback actions, clear=%v add=%v", clearQueueCalled, addQueueCalled)
+	}
+}
+
+func TestSearchAndPlayAction_Run_StrictGenreUsesIntentGenreForPlayback(t *testing.T) {
+	var addExpression string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("expression") != "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+  "tracks": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "artists": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "albums": {"items": [], "total": 0, "offset": 0, "limit": 5},
+  "genres": {"items": [{"name":"Rock","track_count":10}], "total": 1, "offset": 0, "limit": 5},
+  "playlists": {"items": [], "total": 0, "offset": 0, "limit": 5}
+}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptySearchJSONResponse())
+	})
+	mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, r *http.Request) {
+		addExpression = r.URL.Query().Get("expression")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := NewClient(Config{
+		URL:           server.URL,
+		SearchAliases: map[string]string{"ろっく": "rock"},
+	})
+	action := NewSearchAndPlayAction(
+		client,
+		WithMusicIntentResolver(fakeMusicIntentResolver{
+			intent: MusicIntent{
+				GenreCandidates: []string{"ロック"},
+				Confidence:      0.95,
+			},
+		}),
+	)
+
+	_, err := action.Run(context.Background(), "ロック系をかけて")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if addExpression != `genre is "rock"` {
+		t.Fatalf("expression = %q, want %q", addExpression, `genre is "rock"`)
+	}
+}
+
+func TestSearchAndPlayAction_Run_AmbiguousIntentShowsCandidatesWithoutPlaying(t *testing.T) {
+	var addQueueCalled bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, searchSampleJSONResponse())
+	})
+	mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, _ *http.Request) {
+		addQueueCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := NewClient(Config{URL: server.URL})
+	action := NewSearchAndPlayAction(
+		client,
+		WithMusicIntentResolver(fakeMusicIntentResolver{
+			intent: MusicIntent{
+				TrackCandidates: []string{"First Love"},
+				Confidence:      0.99,
+				Ambiguous:       true,
+			},
+		}),
+	)
+
+	got, err := action.Run(context.Background(), "First Loveかけて")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(got, "Candidate results only (no autoplay).") {
+		t.Fatalf("Run() result = %q, want candidate-only message", got)
+	}
+	if addQueueCalled {
+		t.Fatal("expected no playback actions for ambiguous intent")
+	}
+}
+
+func TestWithMusicIntentConfidenceThreshold_AllowsZero(t *testing.T) {
+	action := NewSearchAndPlayAction(
+		NewClient(Config{URL: "http://example.local"}),
+		WithMusicIntentConfidenceThreshold(0),
+	)
+	if action.musicIntentConfidenceThreshold != 0 {
+		t.Fatalf("threshold = %v, want 0", action.musicIntentConfidenceThreshold)
+	}
+}
+
+func TestSearchAndPlayAction_Run_MusicIntentFailureFallsBackToLegacy(t *testing.T) {
+	var searchCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
+		searchCalls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, searchSampleJSONResponse())
+	})
+	mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := NewClient(Config{URL: server.URL})
+	action := NewSearchAndPlayAction(
+		client,
+		WithMusicIntentResolver(fakeMusicIntentResolver{err: fmt.Errorf("boom")}),
+	)
+
+	got, err := action.Run(context.Background(), "keyword")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(got, "And play these items") {
+		t.Fatalf("unexpected result: %q", got)
+	}
+	if searchCalls == 0 {
+		t.Fatal("expected legacy search to be called")
 	}
 }
 

--- a/subcommand/config.go
+++ b/subcommand/config.go
@@ -122,6 +122,22 @@ func (c *Config) overrideWithEnv() {
 			c.Owntone.Timeout = i
 		}
 	}
+	// SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT
+	if val, ok := os.LookupEnv("SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT"); ok {
+		c.Owntone.MusicIntentEndpoint = val
+	}
+	// SMARTHOME_OWNTONE_MUSIC_INTENT_TIMEOUT_SECONDS
+	if val, ok := os.LookupEnv("SMARTHOME_OWNTONE_MUSIC_INTENT_TIMEOUT_SECONDS"); ok {
+		if i, err := strconv.Atoi(val); err == nil {
+			c.Owntone.MusicIntentTimeoutSeconds = i
+		}
+	}
+	// SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD
+	if val, ok := os.LookupEnv("SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD"); ok {
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			c.Owntone.MusicIntentConfidenceThreshold = f
+		}
+	}
 	// SMARTHOME_SWITCHBOT_TOKEN
 	if val, ok := os.LookupEnv("SMARTHOME_SWITCHBOT_TOKEN"); ok {
 		c.Switchbot.Token = val

--- a/subcommand/config.go
+++ b/subcommand/config.go
@@ -136,6 +136,7 @@ func (c *Config) overrideWithEnv() {
 	if val, ok := os.LookupEnv("SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD"); ok {
 		if f, err := strconv.ParseFloat(val, 64); err == nil {
 			c.Owntone.MusicIntentConfidenceThreshold = f
+			c.Owntone.MusicIntentConfidenceThresholdSet = true
 		}
 	}
 	// SMARTHOME_SWITCHBOT_TOKEN
@@ -214,6 +215,38 @@ func (c *Config) overrideWithEnv() {
 	}
 }
 
+func detectOwntoneThresholdSet(configFile string) (bool, error) {
+	// #nosec G304
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return false, err
+	}
+
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, nil
+	}
+
+	var owntoneRaw json.RawMessage
+	for _, key := range []string{"owntone", "Owntone"} {
+		if v, ok := root[key]; ok {
+			owntoneRaw = v
+			break
+		}
+	}
+	if len(owntoneRaw) == 0 {
+		return false, nil
+	}
+
+	var owntoneMap map[string]json.RawMessage
+	if err := json.Unmarshal(owntoneRaw, &owntoneMap); err != nil {
+		return false, nil
+	}
+
+	_, ok := owntoneMap["music_intent_confidence_threshold"]
+	return ok, nil
+}
+
 // LoadConfig loads the configuration from the default directory.
 func LoadConfig() (Config, error) {
 	return LoadConfigFromDir(ConfigDirName)
@@ -272,6 +305,11 @@ func loadConfigJSON(configFile string) (Config, error) {
 			return Config{}, fmt.Errorf("JSON syntax error at byte offset %d: %w", syntaxErr.Offset, syntaxErr)
 		}
 		return Config{}, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	thresholdSet, detectErr := detectOwntoneThresholdSet(configFile)
+	if detectErr == nil {
+		config.Owntone.MusicIntentConfidenceThresholdSet = thresholdSet
 	}
 
 	config.overrideWithEnv()

--- a/subcommand/config_test.go
+++ b/subcommand/config_test.go
@@ -88,6 +88,7 @@ func TestConfig_OverrideWithEnv(t *testing.T) {
 	_ = os.Setenv("SMARTHOME_RESOLVER_PROMPT_VERSION", "2026-04-14")
 	_ = os.Setenv("SMARTHOME_RESOLVER_DSPY_ENDPOINT", "http://env-dspy-endpoint")
 	_ = os.Setenv("SMARTHOME_RESOLVER_DSPY_TIMEOUT_SECONDS", "9")
+	_ = os.Setenv("SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD", "0")
 	_ = os.Setenv("SMARTHOME_INFLUXDB_TOKEN", "env-influx-token")
 	_ = os.Setenv("SMARTHOME_INFLUXDB_URL", "http://env-influx-url")
 	_ = os.Setenv("SMARTHOME_INFLUXDB_BUCKET", "env-bucket")
@@ -104,6 +105,7 @@ func TestConfig_OverrideWithEnv(t *testing.T) {
 		_ = os.Unsetenv("SMARTHOME_RESOLVER_PROMPT_VERSION")
 		_ = os.Unsetenv("SMARTHOME_RESOLVER_DSPY_ENDPOINT")
 		_ = os.Unsetenv("SMARTHOME_RESOLVER_DSPY_TIMEOUT_SECONDS")
+		_ = os.Unsetenv("SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD")
 		_ = os.Unsetenv("SMARTHOME_INFLUXDB_TOKEN")
 		_ = os.Unsetenv("SMARTHOME_INFLUXDB_URL")
 		_ = os.Unsetenv("SMARTHOME_INFLUXDB_BUCKET")
@@ -146,6 +148,12 @@ func TestConfig_OverrideWithEnv(t *testing.T) {
 	}
 	if config.Resolver.DSPyTimeoutSeconds != 9 {
 		t.Errorf("expected dspy timeout 9, got %d", config.Resolver.DSPyTimeoutSeconds)
+	}
+	if config.Owntone.MusicIntentConfidenceThreshold != 0 {
+		t.Errorf("expected owntone threshold 0, got %v", config.Owntone.MusicIntentConfidenceThreshold)
+	}
+	if !config.Owntone.MusicIntentConfidenceThresholdSet {
+		t.Error("expected owntone threshold set flag to be true")
 	}
 	if config.Influxdb.Token != "env-influx-token" {
 		t.Errorf("expected env-influx-token, got %s", config.Influxdb.Token)
@@ -248,6 +256,45 @@ func TestLoadConfigWithPath(t *testing.T) {
 	}
 	if config.Resolver.DSPyTimeoutSeconds != 5 {
 		t.Errorf("expected default dspy timeout 5, got %d", config.Resolver.DSPyTimeoutSeconds)
+	}
+	if config.Owntone.MusicIntentConfidenceThresholdSet {
+		t.Error("expected owntone threshold set flag to be false when key is missing")
+	}
+}
+
+func TestLoadConfigWithPath_OwntoneThresholdExplicitlySet(t *testing.T) {
+	content := `{
+		"Owntone": {"url": "http://localhost:8000", "music_intent_confidence_threshold": 0},
+		"Switchbot": {"token": "token", "secret": "secret"},
+		"Yamaha": {"url": "http://localhost:8080"},
+		"LLM": {"endpoint": "http://localhost:8081", "model": "gpt-4o"},
+		"Influxdb": {"url": "http://localhost:8086", "token": "token", "bucket": "bucket", "org": "org"}
+	}`
+	tmpfile, err := os.CreateTemp("", "config_test_threshold.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Remove(tmpfile.Name())
+	}()
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadConfigWithPath(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("LoadConfigWithPath failed: %v", err)
+	}
+
+	if !config.Owntone.MusicIntentConfidenceThresholdSet {
+		t.Error("expected owntone threshold set flag to be true when key exists")
+	}
+	if config.Owntone.MusicIntentConfidenceThreshold != 0 {
+		t.Errorf("expected threshold 0, got %v", config.Owntone.MusicIntentConfidenceThreshold)
 	}
 }
 

--- a/subcommand/search-and-play.go
+++ b/subcommand/search-and-play.go
@@ -32,12 +32,24 @@ func NewSearchAndPlayMusicCmdDefinition() Definition {
 func NewSearchAndPlayMusicSubcommand(definition Definition, config Config) Subcommand {
 	owntoneClient := owntone.NewClient(config.Owntone)
 	yamahaClient := yamaha.NewClient(config.Yamaha)
+
+	intentResolver := owntone.NewHTTPMusicIntentResolver(
+		config.Owntone.MusicIntentEndpoint,
+		time.Duration(config.Owntone.MusicIntentTimeoutSeconds)*time.Second,
+	)
+
+	searchAction := owntone.NewSearchAndPlayAction(
+		owntoneClient,
+		owntone.WithMusicIntentResolver(intentResolver),
+		owntone.WithMusicIntentConfidenceThreshold(config.Owntone.MusicIntentConfidenceThreshold),
+	)
+
 	return Subcommand{
 		Definition: definition,
 		actions: []action.Action{
 			yamaha.NewPowerOnAction(yamahaClient),
 			yamaha.NewSetInputAction(yamahaClient, "airplay"),
-			owntone.NewSearchAndPlayAction(owntoneClient),
+			searchAction,
 			action.NewNoOpAction(3 * time.Second),
 			yamaha.NewSetVolumeAction(yamahaClient, 39),
 			owntone.NewDisplayOutputsAction(owntoneClient, true),

--- a/subcommand/search-and-play.go
+++ b/subcommand/search-and-play.go
@@ -40,8 +40,7 @@ func NewSearchAndPlayMusicSubcommand(definition Definition, config Config) Subco
 
 	searchAction := owntone.NewSearchAndPlayAction(
 		owntoneClient,
-		owntone.WithMusicIntentResolver(intentResolver),
-		owntone.WithMusicIntentConfidenceThreshold(config.Owntone.MusicIntentConfidenceThreshold),
+		buildSearchAndPlayOptions(config.Owntone, intentResolver)...,
 	)
 
 	return Subcommand{
@@ -56,4 +55,14 @@ func NewSearchAndPlayMusicSubcommand(definition Definition, config Config) Subco
 		},
 		ignoreError: true,
 	}
+}
+
+func buildSearchAndPlayOptions(cfg owntone.Config, resolver owntone.MusicIntentResolver) []owntone.SearchAndPlayActionOption {
+	opts := []owntone.SearchAndPlayActionOption{
+		owntone.WithMusicIntentResolver(resolver),
+	}
+	if cfg.MusicIntentConfidenceThresholdSet {
+		opts = append(opts, owntone.WithMusicIntentConfidenceThreshold(cfg.MusicIntentConfidenceThreshold))
+	}
+	return opts
 }

--- a/subcommand/search-and-play_test.go
+++ b/subcommand/search-and-play_test.go
@@ -1,0 +1,28 @@
+package subcommand
+
+import (
+	"testing"
+
+	"github.com/johtani/smarthome/subcommand/action/owntone"
+)
+
+func TestBuildSearchAndPlayOptions(t *testing.T) {
+	t.Run("without explicit threshold", func(t *testing.T) {
+		cfg := owntone.Config{}
+		opts := buildSearchAndPlayOptions(cfg, nil)
+		if len(opts) != 1 {
+			t.Fatalf("expected 1 option, got %d", len(opts))
+		}
+	})
+
+	t.Run("with explicit threshold", func(t *testing.T) {
+		cfg := owntone.Config{
+			MusicIntentConfidenceThreshold:    0,
+			MusicIntentConfidenceThresholdSet: true,
+		}
+		opts := buildSearchAndPlayOptions(cfg, nil)
+		if len(opts) != 2 {
+			t.Fatalf("expected 2 options, got %d", len(opts))
+		}
+	})
+}

--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -1,11 +1,15 @@
 # DSPy Resolver Server
 
-`smarthome` の `resolver.mode=dspy` で利用する外部 HTTP resolver の最小実装です。
+`smarthome` の外部 HTTP resolver 最小実装です。
+
+- コマンド解決（`resolver.mode=dspy`）: `POST /resolve`
+- Music Intent 解決（`search and play` 強化）: `POST /resolve-music-intent`
 
 ## API
 
 - `GET /healthz`
 - `POST /resolve`
+- `POST /resolve-music-intent`
 
 ### Request (`POST /resolve`)
 
@@ -17,7 +21,7 @@
 }
 ```
 
-### Response
+### Response (`POST /resolve`)
 
 ```json
 {
@@ -28,6 +32,29 @@
 ```
 
 `command` は `command_list` 内の名前に一致するものだけ返します。一致しない場合は空文字列を返します。
+
+### Request (`POST /resolve-music-intent`)
+
+```json
+{
+  "text": "宇多田ヒカルのFirst Loveかけて"
+}
+```
+
+### Response (`POST /resolve-music-intent`)
+
+```json
+{
+  "artist_candidates": ["宇多田ヒカル"],
+  "track_candidates": ["First Love"],
+  "genre_candidates": [],
+  "must_terms": [],
+  "confidence": 0.92,
+  "ambiguous": false,
+  "reason": "artist and track detected",
+  "model": "openai/gpt-4o-mini"
+}
+```
 
 ## Docker Compose (recommended)
 
@@ -63,7 +90,7 @@ docker run --rm -p 8089:8080 `
 
 ## smarthome 側設定
 
-`config/config.json` または環境変数で設定します。
+### コマンド解決（既存）
 
 ```json
 {
@@ -75,10 +102,22 @@ docker run --rm -p 8089:8080 `
 }
 ```
 
+### Music Intent 解決（今回追加）
+
+```json
+{
+  "owntone": {
+    "music_intent_endpoint": "http://localhost:8089/resolve-music-intent",
+    "music_intent_timeout_seconds": 5,
+    "music_intent_confidence_threshold": 0.75
+  }
+}
+```
+
 または環境変数:
 
-- `SMARTHOME_RESOLVER_MODE=dspy`
-- `SMARTHOME_RESOLVER_DSPY_ENDPOINT=http://localhost:8089/resolve`
-- `SMARTHOME_RESOLVER_DSPY_TIMEOUT_SECONDS=5`
+- `SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT=http://localhost:8089/resolve-music-intent`
+- `SMARTHOME_OWNTONE_MUSIC_INTENT_TIMEOUT_SECONDS=5`
+- `SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD=0.75`
 
-DSPy resolver が未設定または失敗した場合、`smarthome` は legacy resolver (LLM) にフォールバックします。
+Resolver が未設定または失敗した場合、`smarthome` は既存検索経路へフォールバックします。

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -25,6 +25,21 @@ class ResolveResponse(BaseModel):
     thought: str
 
 
+class ResolveMusicIntentRequest(BaseModel):
+    text: str = Field(..., min_length=1)
+
+
+class ResolveMusicIntentResponse(BaseModel):
+    artist_candidates: List[str] = Field(default_factory=list)
+    track_candidates: List[str] = Field(default_factory=list)
+    genre_candidates: List[str] = Field(default_factory=list)
+    must_terms: List[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    ambiguous: bool = False
+    reason: str = ""
+    model: str = ""
+
+
 @dataclass
 class CommandEntry:
     name: str
@@ -61,6 +76,17 @@ class ResolveSignature(dspy.Signature):
     rationale = dspy.OutputField(desc="Short reason for selection")
 
 
+class ResolveMusicIntentSignature(dspy.Signature):
+    utterance = dspy.InputField(desc="User input text for music search/play request")
+    artist_candidates = dspy.OutputField(desc="Comma separated artist candidates")
+    track_candidates = dspy.OutputField(desc="Comma separated track candidates")
+    genre_candidates = dspy.OutputField(desc="Comma separated genre candidates")
+    must_terms = dspy.OutputField(desc="Comma separated required terms")
+    confidence = dspy.OutputField(desc="Confidence score between 0.0 and 1.0")
+    ambiguous = dspy.OutputField(desc="true if multiple top candidates remain and autoplay should be avoided")
+    reason = dspy.OutputField(desc="Short explanation")
+
+
 class ResolverModule(dspy.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -74,8 +100,51 @@ class ResolverModule(dspy.Module):
         )
 
 
+class MusicIntentResolverModule(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.predict = dspy.Predict(ResolveMusicIntentSignature)
+
+    def forward(self, utterance: str) -> dspy.Prediction:
+        return self.predict(utterance=utterance)
+
+
 def build_catalog_text(entries: List[CommandEntry]) -> str:
     return "\n".join(f"- {e.name}: {e.description}" for e in entries)
+
+
+def split_candidates(value: str) -> List[str]:
+    if not value:
+        return []
+    parts = re.split(r"[,\n/、|]+", value)
+    seen = set()
+    items: List[str] = []
+    for part in parts:
+        normalized = part.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        items.append(normalized)
+        if len(items) >= 8:
+            break
+    return items
+
+
+def parse_confidence(value: str) -> float:
+    try:
+        score = float(value.strip())
+    except Exception:
+        return 0.0
+    if score < 0:
+        return 0.0
+    if score > 1:
+        return 1.0
+    return score
+
+
+def parse_bool(value: str) -> bool:
+    v = (value or "").strip().lower()
+    return v in {"true", "1", "yes", "y"}
 
 
 MODEL = os.getenv("MODEL", "openai/gpt-4o-mini")
@@ -88,7 +157,8 @@ except Exception:
     pass
 
 resolver = ResolverModule()
-app = FastAPI(title="smarthome-dspy-resolver", version="0.1.0")
+music_intent_resolver = MusicIntentResolverModule()
+app = FastAPI(title="smarthome-dspy-resolver", version="0.2.0")
 
 
 @app.get("/healthz")
@@ -129,3 +199,33 @@ def resolve(req: ResolveRequest) -> ResolveResponse:
             thought = "no compatible command in catalog"
 
     return ResolveResponse(command=command, args=args, thought=thought)
+
+
+@app.post("/resolve-music-intent", response_model=ResolveMusicIntentResponse)
+def resolve_music_intent(req: ResolveMusicIntentRequest) -> ResolveMusicIntentResponse:
+    if not LM_CONFIGURED or not hasattr(dspy.settings, "lm") or dspy.settings.lm is None:
+        raise HTTPException(status_code=503, detail="dspy lm is not configured")
+
+    try:
+        pred = music_intent_resolver(utterance=req.text.strip())
+    except Exception as err:
+        raise HTTPException(status_code=503, detail=f"dspy resolve music intent failed: {err}") from err
+
+    artists = split_candidates((getattr(pred, "artist_candidates", "") or "").strip())
+    tracks = split_candidates((getattr(pred, "track_candidates", "") or "").strip())
+    genres = split_candidates((getattr(pred, "genre_candidates", "") or "").strip())
+    must_terms = split_candidates((getattr(pred, "must_terms", "") or "").strip())
+    confidence = parse_confidence((getattr(pred, "confidence", "") or "").strip())
+    ambiguous = parse_bool((getattr(pred, "ambiguous", "") or "").strip())
+    reason = (getattr(pred, "reason", "") or "").strip()
+
+    return ResolveMusicIntentResponse(
+        artist_candidates=artists,
+        track_candidates=tracks,
+        genre_candidates=genres,
+        must_terms=must_terms,
+        confidence=confidence,
+        ambiguous=ambiguous,
+        reason=reason,
+        model=MODEL,
+    )


### PR DESCRIPTION
## Summary
- search and play に Music Intent 解決フローを追加
- 段階検索を実装（strict AND 検索 -> alias expression 検索 -> 既存 query 検索フォールバック）
- 低信頼/曖昧時は候補提示のみで自動再生を抑制
- Resolver telemetry（decision/execution）を追加
- Owntone 設定に music intent 用パラメータを追加

## Main Changes
- add: subcommand/action/owntone/music_intent.go
- add: subcommand/action/owntone/music_intent_resolver.go
- add: subcommand/action/owntone/music_intent_resolver_test.go
- update: subcommand/action/owntone/search.go
- update: subcommand/action/owntone/search_test.go
- update: subcommand/search-and-play.go
- update: subcommand/action/owntone/client.go
- update: subcommand/config.go
- update: config/config.json.sample

## Behavior Notes
- strict 成功時の genre 再生は intent の genre_candidates を優先
- 同点判定は resolver 側の ambiguous フラグ明示時のみ候補提示へ
- music_intent_confidence_threshold=0 を有効な設定値として許可

## Test
- go test ./...

Closes #167
