### PR TITLE
tools/dspy-resolver: support local OpenAI-compatible LLM via env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 {
   "resolver": {
     "mode": "dspy",
-    "dspy_endpoint": "http://localhost:8089/resolve",
+    "dspy_endpoint": "http://localhost:18080/resolve",
     "dspy_timeout_seconds": 5
   }
 }

--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -88,8 +88,8 @@ docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 curl http://localhost:8089/healthz
 ```
 
-`/healthz` は `model` に加えて `api_base` と `model_type` も返します。  
-LM 初期化に失敗した場合は `503` を返します。
+`/healthz` は `model` に加えて `api_base` / `model_type` / `temperature` / `max_tokens` / `api_key_source` を返します。  
+`LM_TEMPERATURE` または `LM_MAX_TOKENS` が不正値の場合を含め、LM 初期化に失敗した場合は `503` を返します。
 
 Dockerコンテナからホスト上のローカルLLMへ接続する場合、`localhost` ではなく `host.docker.internal` を使ってください。
 

--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -58,33 +58,53 @@
 
 ## Docker Compose (recommended)
 
-1. 環境変数を設定:
+利用可能な主な環境変数:
 
 ```powershell
+# 共通
+$env:MODEL="openai/gpt-4o-mini"
+
+# OpenAI利用時
 $env:OPENAI_API_KEY="<your_api_key>"
+
+# ローカルOpenAI互換(例: llm-swap)利用時
+$env:LM_API_BASE="http://host.docker.internal:11434/v1"
+$env:LM_API_KEY="local-dummy-key"
+$env:LM_MODEL_TYPE="chat"
+# 任意
+$env:LM_TEMPERATURE="0.2"
+$env:LM_MAX_TOKENS="512"
 ```
 
-2. 起動:
+起動:
 
 ```powershell
 docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 ```
 
-3. ヘルスチェック:
+ヘルスチェック:
 
 ```powershell
 curl http://localhost:8089/healthz
 ```
 
-`OPENAI_API_KEY` 未設定などで LM 初期化に失敗した場合は `503` を返します。
+`/healthz` は `model` に加えて `api_base` と `model_type` も返します。  
+LM 初期化に失敗した場合は `503` を返します。
+
+Dockerコンテナからホスト上のローカルLLMへ接続する場合、`localhost` ではなく `host.docker.internal` を使ってください。
 
 ## Docker (single command)
 
 ```powershell
 docker build -f tools/dspy-resolver/Dockerfile -t smarthome-dspy-resolver .
 docker run --rm -p 8089:8080 `
+  -e MODEL=$env:MODEL `
   -e OPENAI_API_KEY=$env:OPENAI_API_KEY `
-  -e MODEL=openai/gpt-4o-mini `
+  -e LM_API_BASE=$env:LM_API_BASE `
+  -e LM_API_KEY=$env:LM_API_KEY `
+  -e LM_MODEL_TYPE=$env:LM_MODEL_TYPE `
+  -e LM_TEMPERATURE=$env:LM_TEMPERATURE `
+  -e LM_MAX_TOKENS=$env:LM_MAX_TOKENS `
   smarthome-dspy-resolver
 ```
 

--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -85,7 +85,7 @@ docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 ヘルスチェック:
 
 ```powershell
-curl http://localhost:8089/healthz
+curl http://localhost:18080/healthz
 ```
 
 `/healthz` は `model` に加えて `api_base` / `model_type` / `temperature` / `max_tokens` / `api_key_source` を返します。  
@@ -97,7 +97,7 @@ Dockerコンテナからホスト上のローカルLLMへ接続する場合、`l
 
 ```powershell
 docker build -f tools/dspy-resolver/Dockerfile -t smarthome-dspy-resolver .
-docker run --rm -p 8089:8080 `
+docker run --rm -p 18080:8080 `
   -e MODEL=$env:MODEL `
   -e OPENAI_API_KEY=$env:OPENAI_API_KEY `
   -e LM_API_BASE=$env:LM_API_BASE `
@@ -116,7 +116,7 @@ docker run --rm -p 8089:8080 `
 {
   "resolver": {
     "mode": "dspy",
-    "dspy_endpoint": "http://localhost:8089/resolve",
+    "dspy_endpoint": "http://localhost:18080/resolve",
     "dspy_timeout_seconds": 5
   }
 }
@@ -127,7 +127,7 @@ docker run --rm -p 8089:8080 `
 ```json
 {
   "owntone": {
-    "music_intent_endpoint": "http://localhost:8089/resolve-music-intent",
+    "music_intent_endpoint": "http://localhost:18080/resolve-music-intent",
     "music_intent_timeout_seconds": 5,
     "music_intent_confidence_threshold": 0.75
   }
@@ -136,7 +136,7 @@ docker run --rm -p 8089:8080 `
 
 または環境変数:
 
-- `SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT=http://localhost:8089/resolve-music-intent`
+- `SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT=http://localhost:18080/resolve-music-intent`
 - `SMARTHOME_OWNTONE_MUSIC_INTENT_TIMEOUT_SECONDS=5`
 - `SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD=0.75`
 

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import dspy
 from fastapi import FastAPI, HTTPException
@@ -148,9 +148,59 @@ def parse_bool(value: str) -> bool:
 
 
 MODEL = os.getenv("MODEL", "openai/gpt-4o-mini")
+LM_API_BASE = (os.getenv("LM_API_BASE", "") or "").strip()
+LM_API_KEY = (os.getenv("LM_API_KEY", "") or "").strip()
+OPENAI_API_KEY = (os.getenv("OPENAI_API_KEY", "") or "").strip()
+LM_MODEL_TYPE = (os.getenv("LM_MODEL_TYPE", "chat") or "").strip()
+LM_TEMPERATURE = (os.getenv("LM_TEMPERATURE", "") or "").strip()
+LM_MAX_TOKENS = (os.getenv("LM_MAX_TOKENS", "") or "").strip()
+
+
+def parse_optional_float(value: str) -> Optional[float]:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def parse_optional_int(value: str) -> Optional[int]:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def build_lm_kwargs() -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {}
+    if LM_API_BASE:
+        kwargs["api_base"] = LM_API_BASE
+    if LM_API_KEY:
+        kwargs["api_key"] = LM_API_KEY
+    elif OPENAI_API_KEY:
+        kwargs["api_key"] = OPENAI_API_KEY
+
+    if LM_MODEL_TYPE:
+        kwargs["model_type"] = LM_MODEL_TYPE
+
+    temperature = parse_optional_float(LM_TEMPERATURE)
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    max_tokens = parse_optional_int(LM_MAX_TOKENS)
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    return kwargs
+
+
+LM_KWARGS = build_lm_kwargs()
 LM_CONFIGURED = False
 try:
-    dspy.configure(lm=dspy.LM(MODEL))
+    dspy.configure(lm=dspy.LM(MODEL, **LM_KWARGS))
     LM_CONFIGURED = True
 except Exception:
     # Keep process alive; request handler returns 503 and smarthome can fallback to legacy.
@@ -164,8 +214,21 @@ app = FastAPI(title="smarthome-dspy-resolver", version="0.2.0")
 @app.get("/healthz")
 def healthz() -> dict:
     if not LM_CONFIGURED:
-        raise HTTPException(status_code=503, detail={"status": "not_ready", "model": MODEL})
-    return {"status": "ok", "model": MODEL}
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "not_ready",
+                "model": MODEL,
+                "api_base": LM_API_BASE,
+                "model_type": LM_MODEL_TYPE,
+            },
+        )
+    return {
+        "status": "ok",
+        "model": MODEL,
+        "api_base": LM_API_BASE,
+        "model_type": LM_MODEL_TYPE,
+    }
 
 
 @app.post("/resolve", response_model=ResolveResponse)

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import dspy
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from lm_config import build_lm_config
 
 class ResolveRequest(BaseModel):
     text: str = Field(..., min_length=1)
@@ -148,61 +149,24 @@ def parse_bool(value: str) -> bool:
 
 
 MODEL = os.getenv("MODEL", "openai/gpt-4o-mini")
-LM_API_BASE = (os.getenv("LM_API_BASE", "") or "").strip()
-LM_API_KEY = (os.getenv("LM_API_KEY", "") or "").strip()
-OPENAI_API_KEY = (os.getenv("OPENAI_API_KEY", "") or "").strip()
-LM_MODEL_TYPE = (os.getenv("LM_MODEL_TYPE", "chat") or "").strip()
-LM_TEMPERATURE = (os.getenv("LM_TEMPERATURE", "") or "").strip()
-LM_MAX_TOKENS = (os.getenv("LM_MAX_TOKENS", "") or "").strip()
-
-
-def parse_optional_float(value: str) -> Optional[float]:
-    if not value:
-        return None
-    try:
-        return float(value)
-    except Exception:
-        return None
-
-
-def parse_optional_int(value: str) -> Optional[int]:
-    if not value:
-        return None
-    try:
-        return int(value)
-    except Exception:
-        return None
-
-
-def build_lm_kwargs() -> Dict[str, Any]:
-    kwargs: Dict[str, Any] = {}
-    if LM_API_BASE:
-        kwargs["api_base"] = LM_API_BASE
-    if LM_API_KEY:
-        kwargs["api_key"] = LM_API_KEY
-    elif OPENAI_API_KEY:
-        kwargs["api_key"] = OPENAI_API_KEY
-
-    if LM_MODEL_TYPE:
-        kwargs["model_type"] = LM_MODEL_TYPE
-
-    temperature = parse_optional_float(LM_TEMPERATURE)
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-
-    max_tokens = parse_optional_int(LM_MAX_TOKENS)
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-
-    return kwargs
-
-
-LM_KWARGS = build_lm_kwargs()
+LM_HEALTH: Dict[str, Any] = {
+    "model": MODEL,
+    "api_base": "",
+    "model_type": "chat",
+    "temperature": None,
+    "max_tokens": None,
+    "api_key_source": "none",
+}
+LM_INIT_ERROR = ""
 LM_CONFIGURED = False
 try:
-    dspy.configure(lm=dspy.LM(MODEL, **LM_KWARGS))
+    lm_conf = build_lm_config()
+    MODEL = lm_conf["model"]
+    LM_HEALTH = lm_conf["health"]
+    dspy.configure(lm=dspy.LM(MODEL, **lm_conf["kwargs"]))
     LM_CONFIGURED = True
-except Exception:
+except Exception as err:
+    LM_INIT_ERROR = str(err)
     # Keep process alive; request handler returns 503 and smarthome can fallback to legacy.
     pass
 
@@ -219,15 +183,22 @@ def healthz() -> dict:
             detail={
                 "status": "not_ready",
                 "model": MODEL,
-                "api_base": LM_API_BASE,
-                "model_type": LM_MODEL_TYPE,
+                "api_base": LM_HEALTH["api_base"],
+                "model_type": LM_HEALTH["model_type"],
+                "temperature": LM_HEALTH["temperature"],
+                "max_tokens": LM_HEALTH["max_tokens"],
+                "api_key_source": LM_HEALTH["api_key_source"],
+                "error": LM_INIT_ERROR,
             },
         )
     return {
         "status": "ok",
         "model": MODEL,
-        "api_base": LM_API_BASE,
-        "model_type": LM_MODEL_TYPE,
+        "api_base": LM_HEALTH["api_base"],
+        "model_type": LM_HEALTH["model_type"],
+        "temperature": LM_HEALTH["temperature"],
+        "max_tokens": LM_HEALTH["max_tokens"],
+        "api_key_source": LM_HEALTH["api_key_source"],
     }
 
 

--- a/tools/dspy-resolver/docker-compose.yml
+++ b/tools/dspy-resolver/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     environment:
       MODEL: ${MODEL:-openai/gpt-4o-mini}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      LM_API_BASE: ${LM_API_BASE:-}
+      LM_API_KEY: ${LM_API_KEY:-}
+      LM_MODEL_TYPE: ${LM_MODEL_TYPE:-chat}
+      LM_TEMPERATURE: ${LM_TEMPERATURE:-}
+      LM_MAX_TOKENS: ${LM_MAX_TOKENS:-}
     ports:
       - "${DSPY_RESOLVER_PORT:-8089}:8080"
     restart: unless-stopped

--- a/tools/dspy-resolver/docker-compose.yml
+++ b/tools/dspy-resolver/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       LM_TEMPERATURE: ${LM_TEMPERATURE:-}
       LM_MAX_TOKENS: ${LM_MAX_TOKENS:-}
     ports:
-      - "${DSPY_RESOLVER_PORT:-8089}:8080"
+      - "${DSPY_RESOLVER_PORT:-18080}:8080"
     restart: unless-stopped

--- a/tools/dspy-resolver/lm_config.py
+++ b/tools/dspy-resolver/lm_config.py
@@ -1,0 +1,77 @@
+"""LM configuration helpers for dspy-resolver."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Mapping, Optional
+
+
+def _get_str(env: Mapping[str, str], key: str, default: str = "") -> str:
+    return (env.get(key, default) or "").strip()
+
+
+def _parse_optional_float_strict(value: str, key: str) -> Optional[float]:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except Exception as err:
+        raise ValueError(f"{key} must be a number: {value}") from err
+
+
+def _parse_optional_int_strict(value: str, key: str) -> Optional[int]:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except Exception as err:
+        raise ValueError(f"{key} must be an integer: {value}") from err
+
+
+def build_lm_config(env: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
+    src = env if env is not None else os.environ
+
+    model = _get_str(src, "MODEL", "openai/gpt-4o-mini")
+    api_base = _get_str(src, "LM_API_BASE")
+    lm_api_key = _get_str(src, "LM_API_KEY")
+    openai_api_key = _get_str(src, "OPENAI_API_KEY")
+    model_type = _get_str(src, "LM_MODEL_TYPE", "chat")
+    temperature_raw = _get_str(src, "LM_TEMPERATURE")
+    max_tokens_raw = _get_str(src, "LM_MAX_TOKENS")
+
+    temperature = _parse_optional_float_strict(temperature_raw, "LM_TEMPERATURE")
+    max_tokens = _parse_optional_int_strict(max_tokens_raw, "LM_MAX_TOKENS")
+
+    api_key_source = "none"
+    api_key = ""
+    if lm_api_key:
+        api_key = lm_api_key
+        api_key_source = "LM_API_KEY"
+    elif openai_api_key:
+        api_key = openai_api_key
+        api_key_source = "OPENAI_API_KEY"
+
+    kwargs: Dict[str, Any] = {}
+    if api_base:
+        kwargs["api_base"] = api_base
+    if api_key:
+        kwargs["api_key"] = api_key
+    if model_type:
+        kwargs["model_type"] = model_type
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    return {
+        "model": model,
+        "kwargs": kwargs,
+        "health": {
+            "model": model,
+            "api_base": api_base,
+            "model_type": model_type,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "api_key_source": api_key_source,
+        },
+    }

--- a/tools/dspy-resolver/test_lm_config.py
+++ b/tools/dspy-resolver/test_lm_config.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from lm_config import build_lm_config
+
+
+class LmConfigTests(unittest.TestCase):
+    def test_prefers_lm_api_key_over_openai_api_key(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "LM_API_KEY": "lm-key",
+                "OPENAI_API_KEY": "openai-key",
+            }
+        )
+        self.assertEqual("lm-key", conf["kwargs"]["api_key"])
+        self.assertEqual("LM_API_KEY", conf["health"]["api_key_source"])
+
+    def test_fallback_to_openai_api_key(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "OPENAI_API_KEY": "openai-key",
+            }
+        )
+        self.assertEqual("openai-key", conf["kwargs"]["api_key"])
+        self.assertEqual("OPENAI_API_KEY", conf["health"]["api_key_source"])
+
+    def test_parses_temperature_and_max_tokens(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "LM_TEMPERATURE": "0.25",
+                "LM_MAX_TOKENS": "512",
+            }
+        )
+        self.assertEqual(0.25, conf["kwargs"]["temperature"])
+        self.assertEqual(512, conf["kwargs"]["max_tokens"])
+        self.assertEqual(0.25, conf["health"]["temperature"])
+        self.assertEqual(512, conf["health"]["max_tokens"])
+
+    def test_invalid_temperature_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            build_lm_config({"LM_TEMPERATURE": "abc"})
+
+    def test_invalid_max_tokens_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            build_lm_config({"LM_MAX_TOKENS": "abc"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support local OpenAI-compatible LM settings for `tools/dspy-resolver`
- add environment-driven LM kwargs (`LM_API_BASE`, `LM_API_KEY`, `LM_MODEL_TYPE`, `LM_TEMPERATURE`, `LM_MAX_TOKENS`) with `OPENAI_API_KEY` fallback
- include `api_base` and `model_type` in `/healthz` for easier troubleshooting
- update docker-compose and README with OpenAI + local llm-swap examples

## Verification
- `golangci-lint run`
- `go test ./...`

Closes #172
