### PR TITLE
Support local LLM config for dspy resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 {
   "resolver": {
     "mode": "dspy",
-    "dspy_endpoint": "http://localhost:18080/resolve",
+    "dspy_endpoint": "http://localhost:18089/resolve",
     "dspy_timeout_seconds": 5
   }
 }

--- a/tools/dspy-resolver/Dockerfile
+++ b/tools/dspy-resolver/Dockerfile
@@ -9,6 +9,7 @@ COPY tools/dspy-resolver/requirements.txt /opt/dspy-resolver/requirements.txt
 RUN pip install --no-cache-dir -r /opt/dspy-resolver/requirements.txt
 
 COPY tools/dspy-resolver/app.py /opt/dspy-resolver/app.py
+COPY tools/dspy-resolver/lm_config.py /opt/dspy-resolver/lm_config.py
 
 EXPOSE 8080
 

--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -85,7 +85,7 @@ docker compose -f tools/dspy-resolver/docker-compose.yml up -d --build
 ヘルスチェック:
 
 ```powershell
-curl http://localhost:18080/healthz
+curl http://localhost:18089/healthz
 ```
 
 `/healthz` は `model` に加えて `api_base` / `model_type` / `temperature` / `max_tokens` / `api_key_source` を返します。  
@@ -97,7 +97,7 @@ Dockerコンテナからホスト上のローカルLLMへ接続する場合、`l
 
 ```powershell
 docker build -f tools/dspy-resolver/Dockerfile -t smarthome-dspy-resolver .
-docker run --rm -p 18080:8080 `
+docker run --rm -p 18089:8080 `
   -e MODEL=$env:MODEL `
   -e OPENAI_API_KEY=$env:OPENAI_API_KEY `
   -e LM_API_BASE=$env:LM_API_BASE `
@@ -116,7 +116,7 @@ docker run --rm -p 18080:8080 `
 {
   "resolver": {
     "mode": "dspy",
-    "dspy_endpoint": "http://localhost:18080/resolve",
+    "dspy_endpoint": "http://localhost:18089/resolve",
     "dspy_timeout_seconds": 5
   }
 }
@@ -127,7 +127,7 @@ docker run --rm -p 18080:8080 `
 ```json
 {
   "owntone": {
-    "music_intent_endpoint": "http://localhost:18080/resolve-music-intent",
+    "music_intent_endpoint": "http://localhost:18089/resolve-music-intent",
     "music_intent_timeout_seconds": 5,
     "music_intent_confidence_threshold": 0.75
   }
@@ -136,7 +136,7 @@ docker run --rm -p 18080:8080 `
 
 または環境変数:
 
-- `SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT=http://localhost:18080/resolve-music-intent`
+- `SMARTHOME_OWNTONE_MUSIC_INTENT_ENDPOINT=http://localhost:18089/resolve-music-intent`
 - `SMARTHOME_OWNTONE_MUSIC_INTENT_TIMEOUT_SECONDS=5`
 - `SMARTHOME_OWNTONE_MUSIC_INTENT_CONFIDENCE_THRESHOLD=0.75`
 

--- a/tools/dspy-resolver/docker-compose.yml
+++ b/tools/dspy-resolver/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       LM_TEMPERATURE: ${LM_TEMPERATURE:-}
       LM_MAX_TOKENS: ${LM_MAX_TOKENS:-}
     ports:
-      - "${DSPY_RESOLVER_PORT:-18080}:8080"
+      - "${DSPY_RESOLVER_PORT:-18089}:8080"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add local OpenAI-compatible LM configuration for dspy-resolver
- expose effective LM settings through /healthz and validate numeric env vars
- include lm_config.py in the Docker image and change the default published port to 18089
- update README examples for the new port and local LM settings

## Verification
- docker compose -f tools/dspy-resolver/docker-compose.yml build dspy-resolver
- docker compose -f tools/dspy-resolver/docker-compose.yml config
- git diff --check