### PR TITLE
Trace LiteLLM request payload preview

### DIFF
--- a/tools/dspy-resolver/README.md
+++ b/tools/dspy-resolver/README.md
@@ -113,6 +113,7 @@ dspy-resolver は OpenTelemetry に対応しています。`OTEL_EXPORTER_OTLP_E
 - `dspy.resolve.music_intent`
 - `dspy.request` event
 - `dspy.response` event
+- `llm.request` event（LiteLLM input callback で取得できた場合）
 - DSPy/LiteLLM 配下の `requests` / `httpx` outgoing HTTP span
 
 記録する主な属性:
@@ -143,6 +144,9 @@ $env:DSPY_RESOLVER_TRACE_INCLUDE_HTTP_BODY="true"
 ```
 
 この場合の preview は先頭 2048 文字に制限されます。
+HTTP client の hook から body が読めない場合は、LiteLLM input callback で取得できた変換済み LLM 入力を
+`llm.request` event の `llm.request_body.preview` に記録します。
+この preview は API key 類を `[redacted]` に置換し、先頭 4096 文字に制限されます。
 
 ## Docker (single command)
 

--- a/tools/dspy-resolver/otel_config.py
+++ b/tools/dspy-resolver/otel_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Mapping, Optional
 
@@ -32,10 +33,16 @@ try:
 except Exception:  # pragma: no cover - httpx instrumentation is optional.
     HTTPXClientInstrumentor = None
 
+try:
+    import litellm
+except Exception:  # pragma: no cover - litellm is provided through dspy.
+    litellm = None
+
 
 TRACER_NAME = "dspy-resolver"
 DEFAULT_SERVICE_NAME = "smarthome-dspy-resolver"
 _http_clients_instrumented = False
+_litellm_instrumented = False
 
 
 class NoopSpan:
@@ -147,6 +154,52 @@ def _body_preview_attrs(prefix: str, body: Any, max_preview_chars: int = 2048) -
     return attrs
 
 
+def _redact_sensitive(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text.lower() in {"api_key", "authorization", "token", "access_token", "secret_key"}:
+                redacted[key_text] = "[redacted]"
+            else:
+                redacted[key_text] = _redact_sensitive(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
+def _json_payload_preview_attrs(prefix: str, payload: Any, max_preview_chars: int = 4096) -> Dict[str, Any]:
+    try:
+        body = json.dumps(_redact_sensitive(payload), ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        body = str(payload)
+    return _body_preview_attrs(prefix, body, max_preview_chars)
+
+
+def _litellm_input_callback(kwargs: Mapping[str, Any]) -> None:
+    if trace is None or not _include_http_body():
+        return
+
+    span = trace.get_current_span()
+    additional_args = kwargs.get("additional_args", {})
+    complete_input = None
+    if isinstance(additional_args, Mapping):
+        complete_input = additional_args.get("complete_input_dict")
+    payload = complete_input if complete_input is not None else kwargs
+    span.add_event(
+        "llm.request",
+        attributes=clean_attributes(
+            {
+                "llm.request.source": "litellm.input_callback",
+                **_json_payload_preview_attrs("llm.request_body", payload),
+            }
+        ),
+    )
+
+
 def _requests_request_hook(span: Any, request: Any) -> None:
     if span is None or not _should_trace_http_body(getattr(request, "url", "")):
         return
@@ -169,6 +222,7 @@ def setup_otel(service_name: str = DEFAULT_SERVICE_NAME) -> None:
 
     _drop_empty_otel_endpoint_env()
     instrument_http_clients()
+    instrument_litellm()
     if not _has_otlp_endpoint():
         return
     if not _otel_provider_is_configurable():
@@ -192,6 +246,18 @@ def instrument_http_clients() -> None:
     if HTTPXClientInstrumentor is not None:
         HTTPXClientInstrumentor().instrument(request_hook=_httpx_request_hook)
     _http_clients_instrumented = True
+
+
+def instrument_litellm() -> None:
+    global _litellm_instrumented
+    if _litellm_instrumented or litellm is None:
+        return
+
+    callbacks = list(getattr(litellm, "input_callback", []) or [])
+    if _litellm_input_callback not in callbacks:
+        callbacks.append(_litellm_input_callback)
+        litellm.input_callback = callbacks
+    _litellm_instrumented = True
 
 
 def instrument_fastapi_app(app: Any) -> None:

--- a/tools/dspy-resolver/test_otel_config.py
+++ b/tools/dspy-resolver/test_otel_config.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from otel_config import (
     _body_preview_attrs,
     _drop_empty_otel_endpoint_env,
+    _json_payload_preview_attrs,
     _should_trace_http_body,
     clean_attributes,
     text_trace_attrs,
@@ -87,6 +88,19 @@ class OtelConfigTests(unittest.TestCase):
 
             self.assertEqual("http://collector:4318", os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"])
             self.assertNotIn("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", os.environ)
+
+    def test_json_payload_preview_attrs_redacts_sensitive_values(self) -> None:
+        payload = {
+            "model": "openai/test",
+            "api_key": "secret",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        with patch.dict(os.environ, {"DSPY_RESOLVER_TRACE_INCLUDE_HTTP_BODY": "true"}):
+            attrs = _json_payload_preview_attrs("llm.request_body", payload)
+
+        self.assertIn('"api_key": "[redacted]"', attrs["llm.request_body.preview"])
+        self.assertIn('"content": "hello"', attrs["llm.request_body.preview"])
+        self.assertNotIn("secret", attrs["llm.request_body.preview"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a LiteLLM input callback to record transformed LLM request payload previews on the current resolver span
- redact API key/token-like fields before writing payload previews
- document that HTTP span body capture can be unavailable and LiteLLM callback payloads are recorded as llm.request events

## Context
The outgoing HTTP instrumentation can emit llm.http.request_body.length=0 when the client request body is not available to the requests/httpx hook. This adds a higher-level fallback so DSPy/LiteLLM payload details can still be inspected when DSPY_RESOLVER_TRACE_INCLUDE_HTTP_BODY=true.

## Verification
- git diff --check
- docker compose -f tools/dspy-resolver/docker-compose.yml config
- golangci-lint run
- go test ./...

Python checks were not run locally because this Windows environment only has the WindowsApps python/python3 placeholders and no py launcher.