### PR TITLE
tools/dspy: support local LM settings in optimize batch

### DIFF
--- a/tools/dspy-resolver/Dockerfile
+++ b/tools/dspy-resolver/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir -r /opt/dspy-resolver/requirements.txt
 COPY tools/dspy-resolver/app.py /opt/dspy-resolver/app.py
 COPY tools/dspy-resolver/lm_config.py /opt/dspy-resolver/lm_config.py
 COPY tools/dspy-resolver/otel_config.py /opt/dspy-resolver/otel_config.py
+COPY tools/dspy_common /opt/dspy_common
 
 EXPOSE 8080
 

--- a/tools/dspy-resolver/lm_config.py
+++ b/tools/dspy-resolver/lm_config.py
@@ -1,77 +1,12 @@
-"""LM configuration helpers for dspy-resolver."""
+"""Compatibility wrapper for the shared DSPy LM configuration helper."""
 
 from __future__ import annotations
 
-import os
-from typing import Any, Dict, Mapping, Optional
+import sys
+from pathlib import Path
 
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
 
-def _get_str(env: Mapping[str, str], key: str, default: str = "") -> str:
-    return (env.get(key, default) or "").strip()
-
-
-def _parse_optional_float_strict(value: str, key: str) -> Optional[float]:
-    if not value:
-        return None
-    try:
-        return float(value)
-    except Exception as err:
-        raise ValueError(f"{key} must be a number: {value}") from err
-
-
-def _parse_optional_int_strict(value: str, key: str) -> Optional[int]:
-    if not value:
-        return None
-    try:
-        return int(value)
-    except Exception as err:
-        raise ValueError(f"{key} must be an integer: {value}") from err
-
-
-def build_lm_config(env: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
-    src = env if env is not None else os.environ
-
-    model = _get_str(src, "MODEL", "openai/gpt-4o-mini")
-    api_base = _get_str(src, "LM_API_BASE")
-    lm_api_key = _get_str(src, "LM_API_KEY")
-    openai_api_key = _get_str(src, "OPENAI_API_KEY")
-    model_type = _get_str(src, "LM_MODEL_TYPE", "chat")
-    temperature_raw = _get_str(src, "LM_TEMPERATURE")
-    max_tokens_raw = _get_str(src, "LM_MAX_TOKENS")
-
-    temperature = _parse_optional_float_strict(temperature_raw, "LM_TEMPERATURE")
-    max_tokens = _parse_optional_int_strict(max_tokens_raw, "LM_MAX_TOKENS")
-
-    api_key_source = "none"
-    api_key = ""
-    if lm_api_key:
-        api_key = lm_api_key
-        api_key_source = "LM_API_KEY"
-    elif openai_api_key:
-        api_key = openai_api_key
-        api_key_source = "OPENAI_API_KEY"
-
-    kwargs: Dict[str, Any] = {}
-    if api_base:
-        kwargs["api_base"] = api_base
-    if api_key:
-        kwargs["api_key"] = api_key
-    if model_type:
-        kwargs["model_type"] = model_type
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-
-    return {
-        "model": model,
-        "kwargs": kwargs,
-        "health": {
-            "model": model,
-            "api_base": api_base,
-            "model_type": model_type,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "api_key_source": api_key_source,
-        },
-    }
+from dspy_common.lm_config import build_lm_config  # noqa: E402,F401

--- a/tools/dspy/Dockerfile
+++ b/tools/dspy/Dockerfile
@@ -12,6 +12,7 @@ COPY tools/dspy/prepare_dataset.py /opt/dspy/prepare_dataset.py
 COPY tools/dspy/optimize_and_evaluate.py /opt/dspy/optimize_and_evaluate.py
 COPY tools/dspy/command_catalog.sample.json /opt/dspy/command_catalog.sample.json
 COPY tools/dspy/run-batch.sh /opt/dspy/run-batch.sh
+COPY tools/dspy_common /opt/dspy_common
 
 RUN chmod +x /opt/dspy/run-batch.sh
 

--- a/tools/dspy/README.md
+++ b/tools/dspy/README.md
@@ -48,11 +48,32 @@ python tools/dspy/prepare_dataset.py `
 
 ## 3) Optimize + Evaluate
 
+### OpenAI
+
 ```powershell
 python tools/dspy/optimize_and_evaluate.py `
   --dataset-jsonl .\tmp\dspy\dataset.jsonl `
   --command-catalog .\tools\dspy\command_catalog.sample.json `
   --model openai/gpt-4o-mini `
+  --report-out .\tmp\dspy\report.json `
+  --min-command-accuracy 0.80 `
+  --min-arg-accuracy 0.60
+```
+
+### OpenAI-compatible local LM
+
+`tools/dspy-resolver` と同じ `LM_*` 設定を利用できます。CLI 引数を指定した場合は環境変数より優先されます。
+
+```powershell
+python tools/dspy/optimize_and_evaluate.py `
+  --dataset-jsonl .\tmp\dspy\dataset.jsonl `
+  --command-catalog .\tools\dspy\command_catalog.sample.json `
+  --model openai/qwen2.5:14b `
+  --api-base http://localhost:11434/v1 `
+  --api-key local-dummy-key `
+  --model-type chat `
+  --temperature 0.2 `
+  --max-tokens 512 `
   --report-out .\tmp\dspy\report.json `
   --min-command-accuracy 0.80 `
   --min-arg-accuracy 0.60
@@ -93,8 +114,37 @@ docker run --rm `
   smarthome-dspy-batch
 ```
 
+ローカルの OpenAI 互換サーバーを使う場合、Docker コンテナからホストへ到達するために `host.docker.internal` を使います。
+
+```powershell
+docker run --rm `
+  -e MODEL=openai/qwen2.5:14b `
+  -e LM_API_BASE=http://host.docker.internal:11434/v1 `
+  -e LM_API_KEY=local-dummy-key `
+  -e LM_MODEL_TYPE=chat `
+  -e LM_TEMPERATURE=0.2 `
+  -e LM_MAX_TOKENS=512 `
+  -e RESOLVER_EVENTS_CSV=/workspace/tmp/resolver-events/resolver-events.csv `
+  -e WORK_DIR=/workspace/tmp/dspy `
+  -v ${PWD}:/workspace `
+  smarthome-dspy-batch
+```
+
 必要に応じて以下も上書きできます。
 
 - `COMMAND_CATALOG`
 - `MIN_COMMAND_ACCURACY`
 - `MIN_ARG_ACCURACY`
+- `LM_API_BASE`
+- `LM_API_KEY`
+- `LM_MODEL_TYPE`
+- `LM_TEMPERATURE`
+- `LM_MAX_TOKENS`
+
+LM 設定の優先順位:
+
+- API key: `--api-key` / wrapper parameter -> `LM_API_KEY` -> `OPENAI_API_KEY`
+- API base: `--api-base` / wrapper parameter -> `LM_API_BASE`
+- Model type: `--model-type` / wrapper parameter -> `LM_MODEL_TYPE` -> `chat`
+- Temperature: `--temperature` / wrapper parameter -> `LM_TEMPERATURE`
+- Max tokens: `--max-tokens` / wrapper parameter -> `LM_MAX_TOKENS`

--- a/tools/dspy/optimize_and_evaluate.py
+++ b/tools/dspy/optimize_and_evaluate.py
@@ -6,11 +6,18 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List
 
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
 import dspy
+
+from dspy_common.lm_config import build_lm_config
 
 
 @dataclass
@@ -162,6 +169,11 @@ def main() -> int:
     parser.add_argument("--dataset-jsonl", required=True)
     parser.add_argument("--command-catalog", required=True)
     parser.add_argument("--model", required=True, help="e.g. openai/gpt-4o-mini")
+    parser.add_argument("--api-base", default=None, help="OpenAI-compatible API base URL")
+    parser.add_argument("--api-key", default=None, help="API key for the configured LM")
+    parser.add_argument("--model-type", default=None, help="DSPy LM model_type, e.g. chat")
+    parser.add_argument("--temperature", default=None, type=float)
+    parser.add_argument("--max-tokens", default=None, type=int)
     parser.add_argument("--report-out", required=True)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--train-ratio", type=float, default=0.8)
@@ -185,7 +197,17 @@ def main() -> int:
     if not dev_rows:
         dev_rows = data[-1:]
 
-    dspy.configure(lm=dspy.LM(args.model))
+    lm_conf = build_lm_config(
+        overrides={
+            "model": args.model,
+            "api_base": args.api_base,
+            "api_key": args.api_key,
+            "model_type": args.model_type,
+            "temperature": args.temperature,
+            "max_tokens": args.max_tokens,
+        }
+    )
+    dspy.configure(lm=dspy.LM(lm_conf["model"], **lm_conf["kwargs"]))
 
     baseline = ResolverProgram()
     baseline_eval = evaluate(baseline, dev_rows, catalog_text)

--- a/tools/dspy/run-batch.ps1
+++ b/tools/dspy/run-batch.ps1
@@ -4,7 +4,17 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WorkDir = ".\\tmp\\dspy",
     [Parameter(Mandatory = $false)]
-    [string]$Model = "openai/gpt-4o-mini"
+    [string]$Model = "openai/gpt-4o-mini",
+    [Parameter(Mandatory = $false)]
+    [string]$ApiBase = "",
+    [Parameter(Mandatory = $false)]
+    [string]$ApiKey = "",
+    [Parameter(Mandatory = $false)]
+    [string]$ModelType = "",
+    [Parameter(Mandatory = $false)]
+    [Nullable[double]]$Temperature = $null,
+    [Parameter(Mandatory = $false)]
+    [Nullable[int]]$MaxTokens = $null
 )
 
 Set-StrictMode -Version Latest
@@ -20,12 +30,32 @@ python tools/dspy/prepare_dataset.py `
   --output-jsonl $datasetPath `
   --min-row-per-request 2
 
-python tools/dspy/optimize_and_evaluate.py `
-  --dataset-jsonl $datasetPath `
-  --command-catalog tools/dspy/command_catalog.sample.json `
-  --model $Model `
-  --report-out $reportPath `
-  --min-command-accuracy 0.80 `
-  --min-arg-accuracy 0.60
+$optimizeArgs = @(
+  "tools/dspy/optimize_and_evaluate.py",
+  "--dataset-jsonl", $datasetPath,
+  "--command-catalog", "tools/dspy/command_catalog.sample.json",
+  "--model", $Model,
+  "--report-out", $reportPath,
+  "--min-command-accuracy", "0.80",
+  "--min-arg-accuracy", "0.60"
+)
+
+if ($ApiBase) {
+  $optimizeArgs += @("--api-base", $ApiBase)
+}
+if ($ApiKey) {
+  $optimizeArgs += @("--api-key", $ApiKey)
+}
+if ($ModelType) {
+  $optimizeArgs += @("--model-type", $ModelType)
+}
+if ($null -ne $Temperature) {
+  $optimizeArgs += @("--temperature", $Temperature.ToString([System.Globalization.CultureInfo]::InvariantCulture))
+}
+if ($null -ne $MaxTokens) {
+  $optimizeArgs += @("--max-tokens", $MaxTokens.ToString([System.Globalization.CultureInfo]::InvariantCulture))
+}
+
+python @optimizeArgs
 
 Write-Output "batch finished: $reportPath"

--- a/tools/dspy/run-batch.sh
+++ b/tools/dspy/run-batch.sh
@@ -7,6 +7,11 @@ MODEL="${MODEL:-openai/gpt-4o-mini}"
 COMMAND_CATALOG="${COMMAND_CATALOG:-/workspace/tools/dspy/command_catalog.sample.json}"
 MIN_COMMAND_ACCURACY="${MIN_COMMAND_ACCURACY:-0.80}"
 MIN_ARG_ACCURACY="${MIN_ARG_ACCURACY:-0.60}"
+LM_API_BASE="${LM_API_BASE:-}"
+LM_API_KEY="${LM_API_KEY:-}"
+LM_MODEL_TYPE="${LM_MODEL_TYPE:-}"
+LM_TEMPERATURE="${LM_TEMPERATURE:-}"
+LM_MAX_TOKENS="${LM_MAX_TOKENS:-}"
 
 if [ ! -f "$RESOLVER_EVENTS_CSV" ]; then
   echo "resolver events csv not found: $RESOLVER_EVENTS_CSV" >&2
@@ -23,12 +28,30 @@ python /opt/dspy/prepare_dataset.py \
   --output-jsonl "$DATASET_JSONL" \
   --min-row-per-request 2
 
-python /opt/dspy/optimize_and_evaluate.py \
+set -- \
   --dataset-jsonl "$DATASET_JSONL" \
   --command-catalog "$COMMAND_CATALOG" \
   --model "$MODEL" \
   --report-out "$REPORT_JSON" \
   --min-command-accuracy "$MIN_COMMAND_ACCURACY" \
   --min-arg-accuracy "$MIN_ARG_ACCURACY"
+
+if [ -n "$LM_API_BASE" ]; then
+  set -- "$@" --api-base "$LM_API_BASE"
+fi
+if [ -n "$LM_API_KEY" ]; then
+  set -- "$@" --api-key "$LM_API_KEY"
+fi
+if [ -n "$LM_MODEL_TYPE" ]; then
+  set -- "$@" --model-type "$LM_MODEL_TYPE"
+fi
+if [ -n "$LM_TEMPERATURE" ]; then
+  set -- "$@" --temperature "$LM_TEMPERATURE"
+fi
+if [ -n "$LM_MAX_TOKENS" ]; then
+  set -- "$@" --max-tokens "$LM_MAX_TOKENS"
+fi
+
+python /opt/dspy/optimize_and_evaluate.py "$@"
 
 echo "batch finished: $REPORT_JSON"

--- a/tools/dspy_common/__init__.py
+++ b/tools/dspy_common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers for DSPy-based tools."""

--- a/tools/dspy_common/lm_config.py
+++ b/tools/dspy_common/lm_config.py
@@ -1,0 +1,111 @@
+"""LM configuration helpers shared by DSPy tools."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Mapping, Optional
+
+
+def _get_str(env: Mapping[str, str], key: str, default: str = "") -> str:
+    return (env.get(key, default) or "").strip()
+
+
+def _override_str(overrides: Mapping[str, Any], key: str) -> str:
+    value = overrides.get(key)
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _parse_optional_float_strict(value: Any, key: str) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except Exception as err:
+        raise ValueError(f"{key} must be a number: {value}") from err
+
+
+def _parse_optional_int_strict(value: Any, key: str) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except Exception as err:
+        raise ValueError(f"{key} must be an integer: {value}") from err
+
+
+def _override_or_env(
+    overrides: Mapping[str, Any],
+    override_key: str,
+    env: Mapping[str, str],
+    env_key: str,
+    default: str = "",
+) -> str:
+    override_value = _override_str(overrides, override_key)
+    if override_value:
+        return override_value
+    return _get_str(env, env_key, default)
+
+
+def build_lm_config(
+    env: Optional[Mapping[str, str]] = None,
+    overrides: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build dspy.LM configuration from environment values and optional overrides."""
+
+    src = env if env is not None else os.environ
+    override_values = overrides or {}
+
+    model = _override_or_env(override_values, "model", src, "MODEL", "openai/gpt-4o-mini")
+    api_base = _override_or_env(override_values, "api_base", src, "LM_API_BASE")
+    model_type = _override_or_env(override_values, "model_type", src, "LM_MODEL_TYPE", "chat")
+
+    temperature_raw: Any = override_values.get("temperature")
+    if temperature_raw is None or temperature_raw == "":
+        temperature_raw = _get_str(src, "LM_TEMPERATURE")
+    max_tokens_raw: Any = override_values.get("max_tokens")
+    if max_tokens_raw is None or max_tokens_raw == "":
+        max_tokens_raw = _get_str(src, "LM_MAX_TOKENS")
+
+    temperature = _parse_optional_float_strict(temperature_raw, "LM_TEMPERATURE")
+    max_tokens = _parse_optional_int_strict(max_tokens_raw, "LM_MAX_TOKENS")
+
+    api_key_source = "none"
+    api_key = _override_str(override_values, "api_key")
+    if api_key:
+        api_key_source = "cli"
+    else:
+        lm_api_key = _get_str(src, "LM_API_KEY")
+        openai_api_key = _get_str(src, "OPENAI_API_KEY")
+        if lm_api_key:
+            api_key = lm_api_key
+            api_key_source = "LM_API_KEY"
+        elif openai_api_key:
+            api_key = openai_api_key
+            api_key_source = "OPENAI_API_KEY"
+
+    kwargs: Dict[str, Any] = {}
+    if api_base:
+        kwargs["api_base"] = api_base
+    if api_key:
+        kwargs["api_key"] = api_key
+    if model_type:
+        kwargs["model_type"] = model_type
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    return {
+        "model": model,
+        "kwargs": kwargs,
+        "health": {
+            "model": model,
+            "api_base": api_base,
+            "model_type": model_type,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "api_key_source": api_key_source,
+        },
+    }

--- a/tools/dspy_common/test_lm_config.py
+++ b/tools/dspy_common/test_lm_config.py
@@ -1,0 +1,89 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dspy_common.lm_config import build_lm_config
+
+
+class LmConfigTests(unittest.TestCase):
+    def test_prefers_lm_api_key_over_openai_api_key(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "LM_API_KEY": "lm-key",
+                "OPENAI_API_KEY": "openai-key",
+            }
+        )
+        self.assertEqual("lm-key", conf["kwargs"]["api_key"])
+        self.assertEqual("LM_API_KEY", conf["health"]["api_key_source"])
+
+    def test_fallback_to_openai_api_key(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "OPENAI_API_KEY": "openai-key",
+            }
+        )
+        self.assertEqual("openai-key", conf["kwargs"]["api_key"])
+        self.assertEqual("OPENAI_API_KEY", conf["health"]["api_key_source"])
+
+    def test_cli_api_key_overrides_environment_keys(self) -> None:
+        conf = build_lm_config(
+            {
+                "LM_API_KEY": "lm-key",
+                "OPENAI_API_KEY": "openai-key",
+            },
+            overrides={"api_key": "cli-key"},
+        )
+        self.assertEqual("cli-key", conf["kwargs"]["api_key"])
+        self.assertEqual("cli", conf["health"]["api_key_source"])
+
+    def test_cli_overrides_lm_options(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/env-model",
+                "LM_API_BASE": "http://env.example/v1",
+                "LM_MODEL_TYPE": "env-chat",
+                "LM_TEMPERATURE": "0.9",
+                "LM_MAX_TOKENS": "128",
+            },
+            overrides={
+                "model": "openai/cli-model",
+                "api_base": "http://cli.example/v1",
+                "model_type": "chat",
+                "temperature": 0.25,
+                "max_tokens": 512,
+            },
+        )
+        self.assertEqual("openai/cli-model", conf["model"])
+        self.assertEqual("http://cli.example/v1", conf["kwargs"]["api_base"])
+        self.assertEqual("chat", conf["kwargs"]["model_type"])
+        self.assertEqual(0.25, conf["kwargs"]["temperature"])
+        self.assertEqual(512, conf["kwargs"]["max_tokens"])
+
+    def test_parses_temperature_and_max_tokens(self) -> None:
+        conf = build_lm_config(
+            {
+                "MODEL": "openai/qwen2.5:14b",
+                "LM_TEMPERATURE": "0.25",
+                "LM_MAX_TOKENS": "512",
+            }
+        )
+        self.assertEqual(0.25, conf["kwargs"]["temperature"])
+        self.assertEqual(512, conf["kwargs"]["max_tokens"])
+        self.assertEqual(0.25, conf["health"]["temperature"])
+        self.assertEqual(512, conf["health"]["max_tokens"])
+
+    def test_invalid_temperature_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            build_lm_config({"LM_TEMPERATURE": "abc"})
+
+    def test_invalid_max_tokens_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            build_lm_config({"LM_MAX_TOKENS": "abc"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add shared DSPy LM configuration helper under `tools/dspy_common`
- Wire `tools/dspy/optimize_and_evaluate.py` to accept OpenAI-compatible local LM settings
- Pass LM settings through PowerShell and shell batch wrappers
- Copy shared helper into DSPy Docker images
- Document OpenAI and local `llm-swap` usage examples

Closes #173

## Verification
- `docker run --rm --entrypoint python -v ${PWD}:/workspace -w /workspace dspy-resolver-dspy-resolver:latest -m unittest tools.dspy_common.test_lm_config tools.dspy-resolver.test_lm_config`
- `docker run --rm --entrypoint python -v ${PWD}:/workspace -w /workspace/tools/dspy dspy-resolver-dspy-resolver:latest -m unittest prepare_dataset_test`
- `docker run --rm --entrypoint python -v ${PWD}:/workspace -w /workspace dspy-resolver-dspy-resolver:latest tools/dspy/optimize_and_evaluate.py --help`
- `docker run --rm --entrypoint sh -v ${PWD}:/workspace -w /workspace dspy-resolver-dspy-resolver:latest -n tools/dspy/run-batch.sh`
- PowerShell parser check for `tools/dspy/run-batch.ps1`
- `golangci-lint run`
- `go test ./...`