### PR TITLE
Skip katakana-to-hiragana conversion for external search (#182)

### DIFF
--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -82,9 +82,11 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	if strings.TrimSpace(searchKeyword) == "" {
 		searchKeyword = originalKeyword
 	}
-	externalKeyword := normalizeSearchKeywordForExternalSearch(originalKeyword, a.c.config.SearchAliases)
-	if strings.TrimSpace(externalKeyword) == "" {
-		externalKeyword = originalKeyword
+	externalKeyword := originalKeyword
+	if a.externalSearcher != nil {
+		if k := normalizeSearchKeywordForExternalSearch(originalKeyword, a.c.config.SearchAliases); strings.TrimSpace(k) != "" {
+			externalKeyword = k
+		}
 	}
 	keywords := buildSearchKeywords(originalKeyword, searchKeyword)
 	types := searchQuery.TypeArray()
@@ -555,42 +557,22 @@ func normalizeSearchKeywordForExternalSearch(keyword string, aliases map[string]
 }
 
 func applySearchAliases(keyword string, aliases map[string]string) string {
-	if len(aliases) == 0 {
-		return keyword
-	}
-
-	normalizedAliases := make(map[string]string, len(aliases))
-	for from, to := range aliases {
-		normalizedFrom := normalizeText(from)
-		normalizedTo := normalizeText(to)
-		if normalizedFrom == "" || normalizedTo == "" {
-			continue
-		}
-		normalizedAliases[normalizedFrom] = normalizedTo
-	}
-
-	if replaced, ok := normalizedAliases[keyword]; ok {
-		return replaced
-	}
-
-	terms := strings.Fields(keyword)
-	for i, term := range terms {
-		if replaced, ok := normalizedAliases[term]; ok {
-			terms[i] = replaced
-		}
-	}
-	return strings.Join(terms, " ")
+	return applyAliasesWithNormalizer(keyword, aliases, normalizeText)
 }
 
 func applySearchAliasesNoKana(keyword string, aliases map[string]string) string {
+	return applyAliasesWithNormalizer(keyword, aliases, normalizeTextNoKana)
+}
+
+func applyAliasesWithNormalizer(keyword string, aliases map[string]string, normalizer func(string) string) string {
 	if len(aliases) == 0 {
 		return keyword
 	}
 
 	normalizedAliases := make(map[string]string, len(aliases))
 	for from, to := range aliases {
-		normalizedFrom := normalizeTextNoKana(from)
-		normalizedTo := normalizeTextNoKana(to)
+		normalizedFrom := normalizer(from)
+		normalizedTo := normalizer(to)
 		if normalizedFrom == "" || normalizedTo == "" {
 			continue
 		}
@@ -611,31 +593,22 @@ func applySearchAliasesNoKana(keyword string, aliases map[string]string) string 
 }
 
 func normalizeText(s string) string {
-	normalized := norm.NFKC.String(s)
-	var b strings.Builder
-	b.Grow(len(normalized))
-
-	for _, r := range normalized {
-		r = katakanaToHiragana(r)
-		switch {
-		case unicode.IsLetter(r), unicode.IsDigit(r):
-			b.WriteRune(unicode.ToLower(r))
-		case unicode.IsSpace(r):
-			b.WriteByte(' ')
-		default:
-			// Treat punctuation/symbols as separators.
-			b.WriteByte(' ')
-		}
-	}
-	return strings.Join(strings.Fields(b.String()), " ")
+	return buildNormalizedText(s, true)
 }
 
 func normalizeTextNoKana(s string) string {
+	return buildNormalizedText(s, false)
+}
+
+func buildNormalizedText(s string, convertKana bool) string {
 	normalized := norm.NFKC.String(s)
 	var b strings.Builder
 	b.Grow(len(normalized))
 
 	for _, r := range normalized {
+		if convertKana {
+			r = katakanaToHiragana(r)
+		}
 		switch {
 		case unicode.IsLetter(r), unicode.IsDigit(r):
 			b.WriteRune(unicode.ToLower(r))

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -19,11 +19,11 @@ import (
 const defaultMusicIntentConfidenceThreshold = 0.75
 
 const (
-	fallbackPathAliasExpression                  = "alias_expression"
-	fallbackPathLegacyQuery                      = "legacy_query"
-	fallbackPathExternalSearch                   = "external_search"
-	fallbackPathExternalSearchFallbackAlias      = "external_search_fallback_alias_expression"
-	fallbackPathExternalSearchFallbackLegacy     = "external_search_fallback_legacy_query"
+	fallbackPathAliasExpression              = "alias_expression"
+	fallbackPathLegacyQuery                  = "legacy_query"
+	fallbackPathExternalSearch               = "external_search"
+	fallbackPathExternalSearchFallbackAlias  = "external_search_fallback_alias_expression"
+	fallbackPathExternalSearchFallbackLegacy = "external_search_fallback_legacy_query"
 )
 
 // SearchAndPlayAction represents an action to search for music and play it on Owntone.
@@ -82,6 +82,10 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 	if strings.TrimSpace(searchKeyword) == "" {
 		searchKeyword = originalKeyword
 	}
+	externalKeyword := normalizeSearchKeywordForExternalSearch(originalKeyword, a.c.config.SearchAliases)
+	if strings.TrimSpace(externalKeyword) == "" {
+		externalKeyword = originalKeyword
+	}
 	keywords := buildSearchKeywords(originalKeyword, searchKeyword)
 	types := searchQuery.TypeArray()
 
@@ -120,7 +124,7 @@ func (a SearchAndPlayAction) Run(ctx context.Context, query string) (string, err
 		}
 	}
 
-	result, fallbackPath, err := a.searchWithFallback(ctx, keywords, searchKeyword, types, searchQuery.Limit)
+	result, fallbackPath, err := a.searchWithFallback(ctx, keywords, searchKeyword, externalKeyword, types, searchQuery.Limit)
 	if err != nil {
 		resolver.RecordExecution(ctx, resolver.ExecutionRecord{
 			ExecutionStatus:  "search_error",
@@ -280,10 +284,10 @@ func (a SearchAndPlayAction) playAndBuildMessage(ctx context.Context, result *Se
 	return strings.Join(msg, "\n"), nil
 }
 
-func (a SearchAndPlayAction) searchWithFallback(ctx context.Context, keywords []string, fallbackKeyword string, types []SearchType, limit int) (*SearchResult, string, error) {
+func (a SearchAndPlayAction) searchWithFallback(ctx context.Context, keywords []string, fallbackKeyword string, externalKeyword string, types []SearchType, limit int) (*SearchResult, string, error) {
 	var externalErr error
 	if a.externalSearcher != nil {
-		result, err := a.externalSearcher.Search(ctx, fallbackKeyword, types, limit)
+		result, err := a.externalSearcher.Search(ctx, externalKeyword, types, limit)
 		if err == nil && totalSearchResultCount(result) > 0 {
 			return result, fallbackPathExternalSearch, nil
 		}
@@ -542,6 +546,14 @@ func normalizeSearchKeyword(keyword string, aliases map[string]string) string {
 	return applySearchAliases(normalized, aliases)
 }
 
+func normalizeSearchKeywordForExternalSearch(keyword string, aliases map[string]string) string {
+	normalized := normalizeTextNoKana(keyword)
+	if normalized == "" {
+		return ""
+	}
+	return applySearchAliasesNoKana(normalized, aliases)
+}
+
 func applySearchAliases(keyword string, aliases map[string]string) string {
 	if len(aliases) == 0 {
 		return keyword
@@ -551,6 +563,34 @@ func applySearchAliases(keyword string, aliases map[string]string) string {
 	for from, to := range aliases {
 		normalizedFrom := normalizeText(from)
 		normalizedTo := normalizeText(to)
+		if normalizedFrom == "" || normalizedTo == "" {
+			continue
+		}
+		normalizedAliases[normalizedFrom] = normalizedTo
+	}
+
+	if replaced, ok := normalizedAliases[keyword]; ok {
+		return replaced
+	}
+
+	terms := strings.Fields(keyword)
+	for i, term := range terms {
+		if replaced, ok := normalizedAliases[term]; ok {
+			terms[i] = replaced
+		}
+	}
+	return strings.Join(terms, " ")
+}
+
+func applySearchAliasesNoKana(keyword string, aliases map[string]string) string {
+	if len(aliases) == 0 {
+		return keyword
+	}
+
+	normalizedAliases := make(map[string]string, len(aliases))
+	for from, to := range aliases {
+		normalizedFrom := normalizeTextNoKana(from)
+		normalizedTo := normalizeTextNoKana(to)
 		if normalizedFrom == "" || normalizedTo == "" {
 			continue
 		}
@@ -584,6 +624,24 @@ func normalizeText(s string) string {
 			b.WriteByte(' ')
 		default:
 			// Treat punctuation/symbols as separators.
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func normalizeTextNoKana(s string) string {
+	normalized := norm.NFKC.String(s)
+	var b strings.Builder
+	b.Grow(len(normalized))
+
+	for _, r := range normalized {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+		case unicode.IsSpace(r):
+			b.WriteByte(' ')
+		default:
 			b.WriteByte(' ')
 		}
 	}

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -123,6 +123,103 @@ func TestNormalizeText(t *testing.T) {
 	}
 }
 
+func TestNormalizeTextNoKana(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "NFKC and lowercase", in: "ＴＥＳＴ　１２３", want: "test 123"},
+		{name: "Symbol collapse", in: "A・B!!! C", want: "a b c"},
+		{name: "Katakana kept as-is", in: "スピッツ", want: "スピッツ"},
+		{name: "Mixed kana not converted", in: "ヒカル ひかる", want: "ヒカル ひかる"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeTextNoKana(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeTextNoKana() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSearchKeywordForExternalSearch(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyword string
+		aliases map[string]string
+		want    string
+	}{
+		{
+			name:    "katakana kept without kana conversion",
+			keyword: "スピッツ",
+			aliases: nil,
+			want:    "スピッツ",
+		},
+		{
+			name:    "alias match without kana conversion",
+			keyword: "MGA",
+			aliases: map[string]string{"ｍｇａ": "Mrs. GREEN APPLE"},
+			want:    "mrs green apple",
+		},
+		{
+			name:    "alias key in katakana matched without conversion",
+			keyword: "ヒッキー",
+			aliases: map[string]string{"ヒッキー": "宇多田ヒカル"},
+			want:    "宇多田ヒカル",
+		},
+		{
+			name:    "empty after normalization",
+			keyword: "!!!",
+			aliases: map[string]string{"x": "y"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeSearchKeywordForExternalSearch(tt.keyword, tt.aliases)
+			if got != tt.want {
+				t.Fatalf("normalizeSearchKeywordForExternalSearch() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchAndPlayAction_Run_ExternalSearchUsesNoKanaKeyword(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/queue/clear", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/queue/items/add", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	external := &fakeExternalSearcher{
+		result: &SearchResult{
+			Tracks: Items{
+				Items: []SearchItem{{Title: "Robinson", Artist: "スピッツ", URI: "library:track:1"}},
+				Total: 1,
+			},
+		},
+	}
+	client := NewClient(Config{URL: server.URL})
+	action := NewSearchAndPlayAction(client, WithExternalSearch(external))
+
+	_, err := action.Run(context.Background(), "スピッツ")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if external.receivedKeyword != "スピッツ" {
+		t.Fatalf("external search keyword = %q, want %q (katakana must not be converted to hiragana)", external.receivedKeyword, "スピッツ")
+	}
+}
+
 func TestNormalizeSearchKeyword(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -335,13 +432,15 @@ func (f fakeMusicIntentResolver) Resolve(_ context.Context, _ string) (MusicInte
 }
 
 type fakeExternalSearcher struct {
-	result *SearchResult
-	err    error
-	calls  int
+	result          *SearchResult
+	err             error
+	calls           int
+	receivedKeyword string
 }
 
-func (f *fakeExternalSearcher) Search(_ context.Context, _ string, _ []SearchType, _ int) (*SearchResult, error) {
+func (f *fakeExternalSearcher) Search(_ context.Context, keyword string, _ []SearchType, _ int) (*SearchResult, error) {
 	f.calls++
+	f.receivedKeyword = keyword
 	if f.err != nil {
 		return nil, f.err
 	}


### PR DESCRIPTION
## Summary

- `external_search`（OpenSearch）向けに、カタカナ→ひらがな変換をスキップした正規化キーワードを送信するよう変更
- OwnTone 向けの正規化（`normalizeSearchKeyword`）は変更なし

## 変更内容

### `subcommand/action/owntone/search.go`

- `normalizeTextNoKana` を追加: `normalizeText` から `katakanaToHiragana` 呼び出しを除いた関数（NFKC正規化・小文字化・記号除去のみ）
- `applySearchAliasesNoKana` を追加: エイリアスキーの照合に `normalizeTextNoKana` を使う版
- `normalizeSearchKeywordForExternalSearch` を追加: 上記2つを組み合わせた外部検索用正規化関数
- `Run()` に `externalKeyword` の計算を追加し `searchWithFallback` に渡す
- `searchWithFallback` に `externalKeyword string` パラメータを追加し、`ExternalSearcher.Search` 呼び出し時のみ使用

### `subcommand/action/owntone/search_test.go`

- `fakeExternalSearcher` に `receivedKeyword` フィールドを追加
- `TestNormalizeTextNoKana`: カタカナがひらがなに変換されないことを確認
- `TestNormalizeSearchKeywordForExternalSearch`: エイリアス照合がカタカナのまま動作することを確認
- `TestSearchAndPlayAction_Run_ExternalSearchUsesNoKanaKeyword`: 外部検索に送信されるキーワードがカタカナのまま（例: "スピッツ"）であることを確認

## Test plan

- [x] `gofmt` 実行済み
- [x] `golangci-lint run` → 0 issues
- [x] `go test ./...` → 全パッケージ PASS

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)