### PR TITLE
Add search.request_body span attribute to external search trace

### DIFF
--- a/subcommand/action/owntone/external_search.go
+++ b/subcommand/action/owntone/external_search.go
@@ -125,6 +125,7 @@ func (s *OpenSearchExternalSearcher) search(ctx context.Context, keyword string,
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode external search request: %w", err)
 	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String("search.request_body", string(body)))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.searchTemplateURL(), bytes.NewReader(body))
 	if err != nil {
@@ -195,7 +196,6 @@ func openSearchResponseToSearchResult(response openSearchTemplateResponse) *Sear
 	setExternalSearchTotals(result)
 	return result
 }
-
 
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {

--- a/subcommand/action/owntone/external_search_test.go
+++ b/subcommand/action/owntone/external_search_test.go
@@ -85,6 +85,16 @@ func TestOpenSearchExternalSearcher_Search(t *testing.T) {
 			if attrValue(span.Attributes, "search.hit_count") != int64(2) {
 				t.Fatalf("search.hit_count = %v, want 2", attrValue(span.Attributes, "search.hit_count"))
 			}
+			reqBody, ok := attrValue(span.Attributes, "search.request_body").(string)
+			if !ok || reqBody == "" {
+				t.Fatalf("search.request_body = %v, want non-empty string", attrValue(span.Attributes, "search.request_body"))
+			}
+			if !strings.Contains(reqBody, "宇多田") {
+				t.Fatalf("search.request_body does not contain keyword: %s", reqBody)
+			}
+			if !strings.Contains(reqBody, "music_search") {
+				t.Fatalf("search.request_body does not contain template id: %s", reqBody)
+			}
 		}
 	}
 	if !found {


### PR DESCRIPTION
## Summary

- `external_search.go` の `search` メソッドで `json.Marshal` 直後に、OpenSearch へ送信するリクエストボディを `search.request_body` スパン属性として記録するようにした
- `external_search_test.go` に `search.request_body` 属性の検証を追加した

## Why

デバッグ・オブザーバビリティの観点から、実際にどのようなリクエストが送信されたかをトレース（Elasticsearch/Kibana、SigNoz）で確認できるようにするため。

Closes #184

## Implementation notes

- `search` メソッドはすでに `ctx` を受け取っており、コンテキストには `Search` が作成したスパンが格納されているため、`trace.SpanFromContext(ctx)` で取得してシグネチャ変更なしに属性をセットした
- Span Event ではなく Span Attribute として記録（両バックエンドで検索・フィルタしやすいため）
- `search.request_body` にはクエリ本文が含まれる（`search.query_hash` と異なりハッシュ化されない）。デバッグ用途として許容する方針

## Test plan

- [x] `go test ./subcommand/action/owntone/...` — PASS
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt` — 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)