### PR TITLE
Add request and response body attributes to dspy.Resolve trace span

### DIFF
--- a/subcommand/find_tracing_test.go
+++ b/subcommand/find_tracing_test.go
@@ -192,7 +192,7 @@ func TestCommandsFindTracing_DSPyPath(t *testing.T) {
 		t.Fatalf("expected dspy.request.command_count 2, got %q", dspyAttrs["dspy.request.command_count"])
 	}
 	if dspyAttrs["dspy.response_body"] != `{"command":"light on","args":"","thought":"resolved by DSPy"}` {
-		t.Fatalf("expected dspy.response_body, got %q", dspyAttrs["dspy.response_body"])
+		t.Fatalf("expected dspy.response_body %s, got %q", `{"command":"light on","args":"","thought":"resolved by DSPy"}`, dspyAttrs["dspy.response_body"])
 	}
 }
 

--- a/subcommand/find_tracing_test.go
+++ b/subcommand/find_tracing_test.go
@@ -182,6 +182,18 @@ func TestCommandsFindTracing_DSPyPath(t *testing.T) {
 	if dspyAttrs["resolver.prompt_version"] != "v2" {
 		t.Fatalf("expected resolver.prompt_version v2, got %q", dspyAttrs["resolver.prompt_version"])
 	}
+	if dspyAttrs["dspy.request.text"] != "あかりをつけて" {
+		t.Fatalf("expected dspy.request.text あかりをつけて, got %q", dspyAttrs["dspy.request.text"])
+	}
+	if dspyAttrs["dspy.request.prompt_version"] != "v2" {
+		t.Fatalf("expected dspy.request.prompt_version v2, got %q", dspyAttrs["dspy.request.prompt_version"])
+	}
+	if dspyAttrs["dspy.request.command_count"] != "2" {
+		t.Fatalf("expected dspy.request.command_count 2, got %q", dspyAttrs["dspy.request.command_count"])
+	}
+	if dspyAttrs["dspy.response_body"] != `{"command":"light on","args":"","thought":"resolved by DSPy"}` {
+		t.Fatalf("expected dspy.response_body, got %q", dspyAttrs["dspy.response_body"])
+	}
 }
 
 func findSpanByName(t *testing.T, exporter *tracetest.InMemoryExporter, name string) tracetest.SpanStub {

--- a/subcommand/resolver_strategy.go
+++ b/subcommand/resolver_strategy.go
@@ -86,6 +86,11 @@ func (r dspyResolver) Resolve(ctx context.Context, text string, commandList stri
 	if err != nil {
 		return llm.ResolvedCommand{}, fmt.Errorf("failed to marshal dspy payload: %w", err)
 	}
+	span.SetAttributes(
+		attribute.String("dspy.request.text", text),
+		attribute.String("dspy.request.prompt_version", promptVersion),
+		attribute.Int("dspy.request.command_count", strings.Count(commandList, "\n")+1),
+	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.endpoint, bytes.NewReader(reqBody))
 	if err != nil {
@@ -105,6 +110,7 @@ func (r dspyResolver) Resolve(ctx context.Context, text string, commandList stri
 	if err != nil {
 		return llm.ResolvedCommand{}, fmt.Errorf("failed to read dspy response: %w", err)
 	}
+	span.SetAttributes(attribute.String("dspy.response_body", string(respBody)))
 	if resp.StatusCode != http.StatusOK {
 		return llm.ResolvedCommand{}, fmt.Errorf("unexpected dspy status code: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
## Summary

- `dspyResolver.Resolve` に `dspy.request.text`、`dspy.request.prompt_version`、`dspy.request.command_count` 属性を追加（`json.Marshal` 直後）
- `dspy.response_body` 属性を追加（`io.ReadAll` 直後）
- `TestCommandsFindTracing_DSPyPath` に新規属性の検証アサーションを追加

Closes #185

## Test plan

- [ ] `go test ./subcommand/...` が全 PASS
- [ ] `golangci-lint run` で 0 issues
- [ ] `TestCommandsFindTracing_DSPyPath` が新しいスパン属性を正しく検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)