### PR TITLE
Fix DSPy keyword extraction by including args hints in command catalog

### DIFF
--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -50,6 +50,9 @@ class ResolveMusicIntentResponse(BaseModel):
     model: str = ""
 
 
+_ARGS_PREFIX = "args:"
+
+
 @dataclass
 class CommandEntry:
     name: str
@@ -64,9 +67,9 @@ def parse_command_list(command_list: str) -> List[CommandEntry]:
         trimmed = line.strip()
         if not trimmed:
             continue
-        if trimmed.startswith("args:"):
+        if trimmed.startswith(_ARGS_PREFIX):
             if last_entry is not None:
-                last_entry.args_text = trimmed[len("args:"):].strip()
+                last_entry.args_text = trimmed[len(_ARGS_PREFIX):].strip()
             continue
         if not line.startswith("  "):
             continue
@@ -126,13 +129,10 @@ class MusicIntentResolverModule(dspy.Module):
 
 
 def build_catalog_text(entries: List[CommandEntry]) -> str:
-    lines = []
-    for e in entries:
-        if e.args_text:
-            lines.append(f"- {e.name}: {e.description} [args: {e.args_text}]")
-        else:
-            lines.append(f"- {e.name}: {e.description}")
-    return "\n".join(lines)
+    return "\n".join(
+        f"- {e.name}: {e.description}" + (f" [args: {e.args_text}]" if e.args_text else "")
+        for e in entries
+    )
 
 
 def split_candidates(value: str) -> List[str]:

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -54,15 +54,19 @@ class ResolveMusicIntentResponse(BaseModel):
 class CommandEntry:
     name: str
     description: str
+    args_text: str = ""
 
 
 def parse_command_list(command_list: str) -> List[CommandEntry]:
     rows: List[CommandEntry] = []
+    last_entry: CommandEntry | None = None
     for line in command_list.splitlines():
         trimmed = line.strip()
         if not trimmed:
             continue
         if trimmed.startswith("args:"):
+            if last_entry is not None:
+                last_entry.args_text = trimmed[len("args:"):].strip()
             continue
         if not line.startswith("  "):
             continue
@@ -73,16 +77,18 @@ def parse_command_list(command_list: str) -> List[CommandEntry]:
         m = re.match(r"^\s*([^\[:]+?)(?:\s*\[[^\]]+\])?\s*:\s*(.+?)\s*$", line)
         if not m:
             continue
-        rows.append(CommandEntry(name=m.group(1).strip(), description=m.group(2).strip()))
+        entry = CommandEntry(name=m.group(1).strip(), description=m.group(2).strip())
+        rows.append(entry)
+        last_entry = entry
     return rows
 
 
 class ResolveSignature(dspy.Signature):
     utterance = dspy.InputField(desc="User input text")
-    command_catalog = dspy.InputField(desc="Command catalog list with names and descriptions")
+    command_catalog = dspy.InputField(desc="Command catalog with names, descriptions, and optional args format hints")
     prompt_version = dspy.InputField(desc="Prompt version for traceability")
     selected_command = dspy.OutputField(desc="Best matching command name. Use empty string if none.")
-    selected_args = dspy.OutputField(desc="Args text for selected command. Empty string when no args.")
+    selected_args = dspy.OutputField(desc="Args for the selected command following the args format hint. For non-prefix required args output the extracted value only (e.g. 'Meja'). For prefix args use prefix:value (e.g. 'type:artist'). Empty string when no args needed.")
     rationale = dspy.OutputField(desc="Short reason for selection")
 
 
@@ -120,7 +126,13 @@ class MusicIntentResolverModule(dspy.Module):
 
 
 def build_catalog_text(entries: List[CommandEntry]) -> str:
-    return "\n".join(f"- {e.name}: {e.description}" for e in entries)
+    lines = []
+    for e in entries:
+        if e.args_text:
+            lines.append(f"- {e.name}: {e.description} [args: {e.args_text}]")
+        else:
+            lines.append(f"- {e.name}: {e.description}")
+    return "\n".join(lines)
 
 
 def split_candidates(value: str) -> List[str]:

--- a/tools/dspy-resolver/test_app.py
+++ b/tools/dspy-resolver/test_app.py
@@ -1,0 +1,105 @@
+"""Tests for parse_command_list and build_catalog_text in app.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from app import CommandEntry, build_catalog_text, parse_command_list
+
+
+COMMAND_LIST_WITH_ARGS = """\
+  search and play : Search Music by keyword And play
+    args: keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)
+  start music : Play music randomly by playlist, artist, or genre
+    args: mode(optional,enum=artist|genre)
+  light on : turn on the light
+"""
+
+COMMAND_LIST_NO_ARGS = """\
+  light on : turn on the light
+  light off : turn off the light
+"""
+
+COMMAND_LIST_WITH_SHORTNAME = """\
+  search and play [search play]: Search Music by keyword And play
+    args: keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)
+"""
+
+
+class TestParseCommandList:
+    def test_command_with_args_captures_args_text(self):
+        entries = parse_command_list(COMMAND_LIST_WITH_ARGS)
+        search_play = next(e for e in entries if e.name == "search and play")
+        assert search_play.args_text == "keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)"
+
+    def test_command_with_args_optional_mode(self):
+        entries = parse_command_list(COMMAND_LIST_WITH_ARGS)
+        start_music = next(e for e in entries if e.name == "start music")
+        assert start_music.args_text == "mode(optional,enum=artist|genre)"
+
+    def test_command_without_args_has_empty_args_text(self):
+        entries = parse_command_list(COMMAND_LIST_WITH_ARGS)
+        light_on = next(e for e in entries if e.name == "light on")
+        assert light_on.args_text == ""
+
+    def test_parses_all_commands(self):
+        entries = parse_command_list(COMMAND_LIST_WITH_ARGS)
+        names = [e.name for e in entries]
+        assert names == ["search and play", "start music", "light on"]
+
+    def test_no_args_commands(self):
+        entries = parse_command_list(COMMAND_LIST_NO_ARGS)
+        assert len(entries) == 2
+        assert all(e.args_text == "" for e in entries)
+
+    def test_shortname_stripped_from_command_name(self):
+        entries = parse_command_list(COMMAND_LIST_WITH_SHORTNAME)
+        assert len(entries) == 1
+        assert entries[0].name == "search and play"
+        assert entries[0].args_text == "keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)"
+
+    def test_empty_input_returns_empty(self):
+        assert parse_command_list("") == []
+
+    def test_args_line_without_preceding_command_is_ignored(self):
+        command_list = "    args: orphan(required)\n  light on : turn on the light\n"
+        entries = parse_command_list(command_list)
+        assert len(entries) == 1
+        assert entries[0].args_text == ""
+
+
+class TestBuildCatalogText:
+    def test_entry_with_args_text_includes_args(self):
+        entries = [
+            CommandEntry(
+                name="search and play",
+                description="Search Music by keyword And play",
+                args_text="keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)",
+            )
+        ]
+        result = build_catalog_text(entries)
+        assert result == (
+            "- search and play: Search Music by keyword And play"
+            " [args: keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)]"
+        )
+
+    def test_entry_without_args_text_excludes_args(self):
+        entries = [CommandEntry(name="light on", description="turn on the light")]
+        result = build_catalog_text(entries)
+        assert result == "- light on: turn on the light"
+
+    def test_mixed_entries(self):
+        entries = [
+            CommandEntry(
+                name="search and play",
+                description="Search Music by keyword And play",
+                args_text="keyword(required)",
+            ),
+            CommandEntry(name="light on", description="turn on the light"),
+        ]
+        lines = build_catalog_text(entries).splitlines()
+        assert lines[0] == "- search and play: Search Music by keyword And play [args: keyword(required)]"
+        assert lines[1] == "- light on: turn on the light"
+
+    def test_empty_entries_returns_empty_string(self):
+        assert build_catalog_text([]) == ""


### PR DESCRIPTION
## Summary

- `CommandEntry` に `args_text` フィールドを追加し、コマンドの引数情報を保持できるようにした
- `parse_command_list` を修正して `args:` 行を直前のコマンドエントリに紐付けてキャプチャするようにした（従来はスキップ）
- `build_catalog_text` を修正して `args_text` があるエントリには `[args: ...]` をカタログテキストに含めるようにした
- `ResolveSignature` の `command_catalog` および `selected_args` フィールドの説明文を更新し、引数フォーマット（プレフィックスあり/なし）をDSPyに伝えるようにした
- `test_app.py` を新規作成し、`parse_command_list`/`build_catalog_text` のユニットテスト12件を追加した

## Test plan

- [ ] `tools/dspy-resolver/test_app.py` 全12テスト通過確認（Docker上でpython:3.11-slim使用）
- [ ] `go test ./...` 全パッケージ通過確認

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)