### PR TITLE
DSPy の args 出力形式の不正修正と Parse() の堅牢化

### DIFF
--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -407,8 +407,7 @@ const typePrefix = "type:"
 const keywordPrefix = "keyword:"
 
 // Parse parses a search query string into a SearchQuery struct.
-// It handles both space-separated and comma-separated args formats, and strips
-// the "keyword:" prefix that DSPy may erroneously prepend to keyword values.
+// Handles comma-separated input and strips "keyword:" prefix that DSPy may prepend erroneously.
 func Parse(target string) *SearchQuery {
 	normalized := strings.ReplaceAll(target, ",", " ")
 	split := strings.Fields(normalized)

--- a/subcommand/action/owntone/search.go
+++ b/subcommand/action/owntone/search.go
@@ -404,16 +404,24 @@ func (sq SearchQuery) TypeArray() []SearchType {
 const limitPrefix = "limit:"
 const offsetPrefix = "offset:"
 const typePrefix = "type:"
+const keywordPrefix = "keyword:"
 
 // Parse parses a search query string into a SearchQuery struct.
+// It handles both space-separated and comma-separated args formats, and strips
+// the "keyword:" prefix that DSPy may erroneously prepend to keyword values.
 func Parse(target string) *SearchQuery {
-	split := strings.Fields(target)
+	normalized := strings.ReplaceAll(target, ",", " ")
+	split := strings.Fields(normalized)
 	var queries []string
 	var types []SearchType
 	limit := -1
 	offset := -1
 	for _, term := range split {
 		switch {
+		case strings.HasPrefix(term, keywordPrefix):
+			if value := term[len(keywordPrefix):]; value != "" {
+				queries = append(queries, value)
+			}
 		case strings.HasPrefix(term, limitPrefix):
 			value := term[len(limitPrefix):]
 			i, err := strconv.Atoi(value)

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -28,6 +28,9 @@ func TestParse(t *testing.T) {
 		{name: "Term and offset, limit, types", args: args{target: "term offset:1 limit:2 type:album type:artist"}, want: &SearchQuery{Terms: []string{"term"}, Offset: 1, Limit: 2, Types: []SearchType{album, artist}}},
 		{name: "Term genre type", args: args{target: "term type:genre"}, want: &SearchQuery{Terms: []string{"term"}, Offset: -1, Limit: -1, Types: []SearchType{genre}}},
 		{name: "Term genre type misspelled", args: args{target: "term type:gener"}, want: &SearchQuery{Terms: []string{"term"}, Offset: -1, Limit: -1, Types: []SearchType{genre}}},
+		{name: "keyword prefix stripped", args: args{target: "keyword:メイヤ"}, want: &SearchQuery{Terms: []string{"メイヤ"}, Offset: -1, Limit: -1}},
+		{name: "keyword prefix with type space-separated", args: args{target: "keyword:メイヤ type:artist"}, want: &SearchQuery{Terms: []string{"メイヤ"}, Offset: -1, Limit: -1, Types: []SearchType{artist}}},
+		{name: "keyword prefix with type comma-separated", args: args{target: "keyword:メイヤ,type:artist"}, want: &SearchQuery{Terms: []string{"メイヤ"}, Offset: -1, Limit: -1, Types: []SearchType{artist}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -135,7 +135,7 @@ def build_catalog_text(entries: List[CommandEntry]) -> str:
         if e.args_text:
             annotated = re.sub(
                 r"\(([^)]*)\)",
-                lambda m: "(" + m.group(1) + ",no-prefix)" if "prefix=" not in m.group(1) else "(" + m.group(1) + ")",
+                lambda m: "(" + m.group(1) + (",no-prefix)" if "prefix=" not in m.group(1) else ")"),
                 e.args_text,
             )
             args_hint = f" [args: {annotated}]"

--- a/tools/dspy-resolver/app.py
+++ b/tools/dspy-resolver/app.py
@@ -91,7 +91,7 @@ class ResolveSignature(dspy.Signature):
     command_catalog = dspy.InputField(desc="Command catalog with names, descriptions, and optional args format hints")
     prompt_version = dspy.InputField(desc="Prompt version for traceability")
     selected_command = dspy.OutputField(desc="Best matching command name. Use empty string if none.")
-    selected_args = dspy.OutputField(desc="Args for the selected command following the args format hint. For non-prefix required args output the extracted value only (e.g. 'Meja'). For prefix args use prefix:value (e.g. 'type:artist'). Empty string when no args needed.")
+    selected_args = dspy.OutputField(desc="Args for the selected command following the args format hint. For non-prefix required args output the extracted value only, never add the arg name as prefix (e.g. 'Meja', not 'keyword:Meja'). For prefix args use prefix:value (e.g. 'type:artist'). Multiple args are space-separated (e.g. 'Meja type:artist'). Empty string when no args needed.")
     rationale = dspy.OutputField(desc="Short reason for selection")
 
 
@@ -129,10 +129,18 @@ class MusicIntentResolverModule(dspy.Module):
 
 
 def build_catalog_text(entries: List[CommandEntry]) -> str:
-    return "\n".join(
-        f"- {e.name}: {e.description}" + (f" [args: {e.args_text}]" if e.args_text else "")
-        for e in entries
-    )
+    lines = []
+    for e in entries:
+        args_hint = ""
+        if e.args_text:
+            annotated = re.sub(
+                r"\(([^)]*)\)",
+                lambda m: "(" + m.group(1) + ",no-prefix)" if "prefix=" not in m.group(1) else "(" + m.group(1) + ")",
+                e.args_text,
+            )
+            args_hint = f" [args: {annotated}]"
+        lines.append(f"- {e.name}: {e.description}{args_hint}")
+    return "\n".join(lines)
 
 
 def split_candidates(value: str) -> List[str]:

--- a/tools/dspy-resolver/test_app.py
+++ b/tools/dspy-resolver/test_app.py
@@ -80,7 +80,7 @@ class TestBuildCatalogText:
         result = build_catalog_text(entries)
         assert result == (
             "- search and play: Search Music by keyword And play"
-            " [args: keyword(required), type(optional,prefix=type:,enum=artist|album|track|genre)]"
+            " [args: keyword(required,no-prefix), type(optional,prefix=type:,enum=artist|album|track|genre)]"
         )
 
     def test_entry_without_args_text_excludes_args(self):
@@ -98,7 +98,7 @@ class TestBuildCatalogText:
             CommandEntry(name="light on", description="turn on the light"),
         ]
         lines = build_catalog_text(entries).splitlines()
-        assert lines[0] == "- search and play: Search Music by keyword And play [args: keyword(required)]"
+        assert lines[0] == "- search and play: Search Music by keyword And play [args: keyword(required,no-prefix)]"
         assert lines[1] == "- light on: turn on the light"
 
     def test_empty_entries_returns_empty_string(self):


### PR DESCRIPTION
## 概要

- `ResolveSignature` の `selected_args` 説明を改善し、DSPy が `keyword:` プレフィックスを付けたりコンマ区切りで出力したりしないようにする
- `build_catalog_text()` でプレフィックスなし arg に `no-prefix` アノテーションを追加し、モデルがプレフィックス必須の arg と区別できるようにする
- `Parse()` にコンマ正規化と `keyword:` プレフィックス除去を追加し、誤った形式への防御的フォールバックとする
- `test_app.py` のテストアサーションを更新し、`build_catalog_text()` の lambda を簡略化

## 背景

DSPy が「search and play」コマンドを解決する際、`メイヤ type:artist` の正しい形式ではなく `keyword:メイヤ,type:artist` という形式で args を返すことがあった。これにより以下の問題が連鎖していた：

1. `Parse()` が文字列全体を1トークンとして扱う → `type:artist` が抽出されず全タイプにフォールバック
2. `keyword:` プレフィックスが除去されず `/resolve-music-intent` にそのまま渡される
3. `externalsearch.search` のクエリが `{"query":"keyword メイヤ type artist","type":"artist,album,track,genre","size":5}` になる

根本原因：カタログテキストが `keyword(required)` と表示され、プレフィックスなし arg との区別が不明確だった。また `selected_args` の説明に複数 args の組み合わせ例がなかった。

## 変更内容

### `tools/dspy-resolver/app.py`
- `selected_args` の説明に否定例（`'keyword:Meja'` は NG）と組み合わせ例（`'Meja type:artist'`）を追加
- `build_catalog_text()` でプレフィックスなし arg に `no-prefix` を付与（例: `keyword(required,no-prefix)`）
- lambda を簡略化：`"(" + m.group(1)` の重複を解消

### `tools/dspy-resolver/test_app.py`
- `keyword` arg に `no-prefix` アノテーションが付くことを反映してテストアサーションを更新

### `subcommand/action/owntone/search.go`
- `Parse()` でコンマをスペースに正規化し `keyword:メイヤ,type:artist` 形式に対応
- `keywordPrefix` 定数を追加し `keyword:` プレフィックスを除去して値だけを検索ワードとして使用
- コメントを WHY のみに簡略化

### `subcommand/action/owntone/search_test.go`
- `TestParse` に3ケースを追加：keyword プレフィックスのみ・スペース区切り・コンマ区切り

## テスト

- [x] `go test ./...` — 全パッケージ PASS
- [ ] DSPy リゾルバーが `keyword:メイヤ,type:artist` 形式を返す状況での手動確認

Closes #192