### PR TITLE
Send OpenSearch types array

### DIFF
--- a/subcommand/action/owntone/external_search.go
+++ b/subcommand/action/owntone/external_search.go
@@ -56,9 +56,10 @@ type openSearchTemplateRequest struct {
 }
 
 type openSearchTemplateParams struct {
-	Query string `json:"query"`
-	Type  string `json:"type,omitempty"`
-	Size  int    `json:"size"`
+	Query    string   `json:"query"`
+	Types    []string `json:"types,omitempty"`
+	HasTypes bool     `json:"has_types,omitempty"`
+	Size     int      `json:"size"`
 }
 
 type openSearchTemplateResponse struct {
@@ -86,7 +87,8 @@ func (s *OpenSearchExternalSearcher) Search(ctx context.Context, keyword string,
 	if l <= 0 {
 		l = 5
 	}
-	typeParam := searchTypesParam(resultTypes)
+	typeParams := searchTypesParams(resultTypes)
+	typeAttr := strings.Join(typeParams, ",")
 
 	ctx, span := otel.Tracer("owntone").Start(ctx, "owntone.ExternalSearch.Search")
 	defer span.End()
@@ -95,11 +97,11 @@ func (s *OpenSearchExternalSearcher) Search(ctx context.Context, keyword string,
 		attribute.String("search.index", s.config.Index),
 		attribute.String("search.template_id", s.config.TemplateID),
 		attribute.String("search.query_hash", hashInputText(keyword)),
-		attribute.String("search.type", typeParam),
+		attribute.String("search.type", typeAttr),
 		attribute.Int("search.limit", l),
 	)
 
-	result, err := s.search(ctx, keyword, typeParam, l)
+	result, err := s.search(ctx, keyword, typeParams, l)
 	if err != nil {
 		recordExternalSearchFailure(span, externalSearchFallbackReason(err), err)
 		return nil, err
@@ -113,13 +115,14 @@ func (s *OpenSearchExternalSearcher) Search(ctx context.Context, keyword string,
 	return result, nil
 }
 
-func (s *OpenSearchExternalSearcher) search(ctx context.Context, keyword string, typeParam string, limit int) (*SearchResult, error) {
+func (s *OpenSearchExternalSearcher) search(ctx context.Context, keyword string, typeParams []string, limit int) (*SearchResult, error) {
 	body, err := json.Marshal(openSearchTemplateRequest{
 		ID: s.config.TemplateID,
 		Params: openSearchTemplateParams{
-			Query: keyword,
-			Type:  typeParam,
-			Size:  limit,
+			Query:    keyword,
+			Types:    typeParams,
+			HasTypes: len(typeParams) > 0,
+			Size:     limit,
 		},
 	})
 	if err != nil {
@@ -214,15 +217,15 @@ func setExternalSearchTotals(result *SearchResult) {
 	}
 }
 
-func searchTypesParam(types []SearchType) string {
+func searchTypesParams(types []SearchType) []string {
 	if len(types) == 0 {
-		return ""
+		return nil
 	}
 	values := make([]string, 0, len(types))
 	for _, t := range types {
 		values = append(values, string(t))
 	}
-	return strings.Join(values, ",")
+	return values
 }
 
 func recordExternalSearchFailure(span trace.Span, reason string, err error) {

--- a/subcommand/action/owntone/external_search_test.go
+++ b/subcommand/action/owntone/external_search_test.go
@@ -59,8 +59,11 @@ func TestOpenSearchExternalSearcher_Search(t *testing.T) {
 	if received.Params.Query != "宇多田" {
 		t.Fatalf("query = %q", received.Params.Query)
 	}
-	if received.Params.Type != "track" {
-		t.Fatalf("type = %q", received.Params.Type)
+	if !reflect.DeepEqual(received.Params.Types, []string{"track"}) {
+		t.Fatalf("types = %v", received.Params.Types)
+	}
+	if !received.Params.HasTypes {
+		t.Fatal("has_types = false, want true")
 	}
 	if received.Params.Size != 2 {
 		t.Fatalf("size = %d", received.Params.Size)
@@ -99,6 +102,52 @@ func TestOpenSearchExternalSearcher_Search(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected owntone.ExternalSearch.Search span")
+	}
+}
+
+func TestOpenSearchExternalSearcher_SearchSendsTypesArrayForDefaultTypes(t *testing.T) {
+	var receivedRaw map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedRaw); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, openSearchSampleResponse())
+	}))
+	defer server.Close()
+
+	searcher := NewOpenSearchExternalSearcher(ExternalSearchConfig{
+		OpenSearchURL: server.URL,
+		Index:         "smarthome-owntone-music",
+		TemplateID:    "music_search",
+	})
+
+	_, err := searcher.Search(context.Background(), "メイヤ", []SearchType{artist, album, track, genre}, 5)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+
+	params, ok := receivedRaw["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params = %#v", receivedRaw["params"])
+	}
+	if _, ok := params["type"]; ok {
+		t.Fatalf("params.type is present: %#v", params["type"])
+	}
+	types, ok := params["types"].([]any)
+	if !ok {
+		t.Fatalf("params.types = %#v", params["types"])
+	}
+	gotTypes := make([]string, 0, len(types))
+	for _, value := range types {
+		gotTypes = append(gotTypes, value.(string))
+	}
+	wantTypes := []string{"artist", "album", "track", "genre"}
+	if !reflect.DeepEqual(gotTypes, wantTypes) {
+		t.Fatalf("params.types = %v, want %v", gotTypes, wantTypes)
+	}
+	if params["has_types"] != true {
+		t.Fatalf("params.has_types = %#v, want true", params["has_types"])
 	}
 }
 

--- a/subcommand/action/owntone/search_test.go
+++ b/subcommand/action/owntone/search_test.go
@@ -221,6 +221,9 @@ func TestSearchAndPlayAction_Run_ExternalSearchUsesNoKanaKeyword(t *testing.T) {
 	if external.receivedKeyword != "スピッツ" {
 		t.Fatalf("external search keyword = %q, want %q (katakana must not be converted to hiragana)", external.receivedKeyword, "スピッツ")
 	}
+	if !reflect.DeepEqual(external.receivedTypes, []SearchType{artist, album, track, genre}) {
+		t.Fatalf("external search types = %v, want default types", external.receivedTypes)
+	}
 }
 
 func TestNormalizeSearchKeyword(t *testing.T) {
@@ -439,11 +442,13 @@ type fakeExternalSearcher struct {
 	err             error
 	calls           int
 	receivedKeyword string
+	receivedTypes   []SearchType
 }
 
-func (f *fakeExternalSearcher) Search(_ context.Context, keyword string, _ []SearchType, _ int) (*SearchResult, error) {
+func (f *fakeExternalSearcher) Search(_ context.Context, keyword string, types []SearchType, _ int) (*SearchResult, error) {
 	f.calls++
 	f.receivedKeyword = keyword
+	f.receivedTypes = append([]SearchType(nil), types...)
 	if f.err != nil {
 		return nil, f.err
 	}


### PR DESCRIPTION
## Summary

- Send OpenSearch search template params as `types` array plus `has_types`
- Stop sending comma-separated `params.type` for external music search
- Add tests for single-type, default multi-type, and SearchAndPlay default type forwarding

## Tests

- `go test ./subcommand/action/owntone`
- `go test ./...`
- `golangci-lint run`

Closes #194
