### PR TITLE
Update Go to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/johtani/smarthome
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/go-co-op/gocron/v2 v2.12.1


### PR DESCRIPTION
## Summary
- update the Go patch version from 1.25.11 to 1.25.12
- resolve standard library vulnerability GO-2026-5856 reported by govulncheck

## Test plan
- [x] `go test ./...`
- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- [x] `git diff --check`

🤖 Generated with [Codex](https://Codex.com/Codex)
